### PR TITLE
Updated redemption model

### DIFF
--- a/contracts/libraries/VaultDeposit.sol
+++ b/contracts/libraries/VaultDeposit.sol
@@ -7,7 +7,7 @@ library VaultDeposit {
         bool processed;
         // Maximum of 65535 rounds. Assuming 1 round is 7 days, maximum is 1256 years.
         uint16 round;
-        // Deposit amount, max 20,282,409,603,651 or 20 billion ETH deposit
+        // Deposit amount, max 20,282,409,603,651 or 20 trillion ETH deposit
         uint104 amount;
         // Unredeemed shares balance
         uint128 unredeemedShares;

--- a/contracts/libraries/VaultDeposit.sol
+++ b/contracts/libraries/VaultDeposit.sol
@@ -7,7 +7,9 @@ library VaultDeposit {
         bool processed;
         // Maximum of 65535 rounds. Assuming 1 round is 7 days, maximum is 1256 years.
         uint16 round;
-        // Deposit amount
-        uint128 amount;
+        // Deposit amount, max 20,282,409,603,651 or 20 billion ETH deposit
+        uint104 amount;
+        // Unredeemed shares balance
+        uint128 unredeemedShares;
     }
 }

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -36,9 +36,6 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
     address public immutable WETH;
     address public immutable USDC;
 
-    // 90% locked in options protocol, 10% of the pool reserved for withdrawals
-    uint256 public constant lockedRatio = 0.9 ether;
-
     uint256 public constant delay = 1 hours;
 
     uint256 public constant period = 7 days;
@@ -720,6 +717,19 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
     function pricePerShare() external view returns (uint256) {
         uint256 balance = totalBalance().sub(totalPending());
         return (10**uint256(_decimals)).mul(balance).div(totalSupply());
+    }
+
+    /**
+     * @notice Returns the expiry of the current option the vault is shorting
+     */
+    function currentOptionExpiry() external view returns (uint256) {
+        address _currentOption = currentOption;
+        if (_currentOption == address(0)) {
+            return 0;
+        }
+
+        IOtoken oToken = IOtoken(_currentOption);
+        return oToken.expiryTimestamp();
     }
 
     /**

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -385,17 +385,15 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         shares = isMax ? unredeemedShares : shares;
         require(shares <= unredeemedShares, "Exceeds available");
 
-        if (depositReceipt.processed) {
+        // When the depositReceipt is processed, we need subtract the shares being redeemed
+        // from the `unredeemedShares`.
+        // Alternatively, if we try to redeem more than the current round's shares
+        // We need to subtract the additional shares from `unredeemedShares`.
+        if (depositReceipt.processed || shares > roundShares) {
             depositReceipts[msg.sender].unredeemedShares = uint128(
                 uint256(depositReceipt.unredeemedShares).sub(shares)
             );
-        } else {
-            if (shares > roundShares) {
-                depositReceipts[msg.sender].unredeemedShares = uint128(
-                    uint256(depositReceipt.unredeemedShares).sub(shares)
-                );
-            }
-
+        } else if (!depositReceipt.processed) {
             depositReceipts[msg.sender].processed = true;
         }
 

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -722,51 +722,6 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         return (10**uint256(_decimals)).mul(balance).div(totalSupply());
     }
 
-    // /**
-    //  * @notice This is the user's share balance, including the shares that are not redeemed from processed deposits.
-    //  * @param account is the address to lookup the balance for.
-    //  */
-    // function balancePlusUnredeemed(address account)
-    //     external
-    //     view
-    //     returns (uint256)
-    // {
-    //     return balanceOf(account).add(unredeemedBalance(account));
-    // }
-
-    // /**
-    //  * @notice Returns the user's unredeemed share amount
-    //  * @param account is the address to lookup the unredeemed share amount
-    //  */
-    // function unredeemedBalance(address account)
-    //     public
-    //     view
-    //     returns (uint256 unredeemedShares)
-    // {
-    //     VaultDeposit.DepositReceipt storage depositReceipt =
-    //         depositReceipts[account];
-
-    //     if (!depositReceipt.processed) {
-    //         unredeemedShares = wmul(
-    //             depositReceipt.amount,
-    //             roundPricePerShare[depositReceipt.round]
-    //         );
-    //     }
-    // }
-
-    /**
-     * @notice Returns the expiry of the current option the vault is shorting
-     */
-    function currentOptionExpiry() external view returns (uint256) {
-        address _currentOption = currentOption;
-        if (_currentOption == address(0)) {
-            return 0;
-        }
-
-        IOtoken oToken = IOtoken(_currentOption);
-        return oToken.expiryTimestamp();
-    }
-
     /**
      * @notice Returns the vault's total balance, including the amounts locked into a short position
      * @return total balance of the vault, including the amounts locked in third party protocols

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -370,15 +370,14 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         VaultDeposit.DepositReceipt memory depositReceipt =
             depositReceipts[msg.sender];
 
-        require(!depositReceipt.processed, "Processed");
         // This handles the null case when depositReceipt.round = 0
         // Because we start with round = 1 at `initialize`
         require(depositReceipt.round < round, "Round not closed");
-        require(depositReceipt.amount > 0, "!amount");
 
         uint128 unredeemedShares = _getSharesFromReceipt(depositReceipt);
 
         shares = isMax ? unredeemedShares : shares;
+        require(shares > 0, "!shares");
         require(shares <= unredeemedShares, "Exceeds available");
 
         depositReceipts[msg.sender] = VaultDeposit.DepositReceipt({

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -392,12 +392,12 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
         require(shares > 0, "!shares");
         require(shares <= unredeemedShares, "Exceeds available");
 
-        depositReceipts[msg.sender] = VaultDeposit.DepositReceipt({
-            processed: true,
-            round: depositReceipt.round,
-            amount: depositReceipt.amount,
-            unredeemedShares: uint128(uint256(unredeemedShares).sub(shares))
-        });
+        // This zeroes out any pending amount from depositReceipt
+        depositReceipts[msg.sender].amount = 0;
+        depositReceipts[msg.sender].processed = true;
+        depositReceipts[msg.sender].unredeemedShares = uint128(
+            uint256(unredeemedShares).sub(shares)
+        );
 
         emit Redeem(msg.sender, shares, depositReceipt.round);
 

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -374,6 +374,8 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
             depositReceipts[msg.sender];
 
         require(!depositReceipt.processed, "Processed");
+        // This handles the null case when depositReceipt.round = 0
+        // Because we start with round = 1 at `initialize`
         require(depositReceipt.round < round, "Round not closed");
         require(depositReceipt.amount > 0, "!amount");
 

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1577,11 +1577,13 @@ function behavesLikeRibbonOptionsVault(params: {
           .to.emit(vault, "Redeem")
           .withArgs(user, params.depositAmount, 1);
 
-        const { processed, round, amount } = await vault.depositReceipts(user);
+        const { processed, round, amount, unredeemedShares } =
+          await vault.depositReceipts(user);
 
         assert.isTrue(processed);
         assert.equal(round, 1);
-        assert.bnEqual(amount, params.depositAmount);
+        assert.bnEqual(amount, BigNumber.from(0));
+        assert.bnEqual(unredeemedShares, BigNumber.from(0));
       });
 
       it("reverts when redeeming twice", async function () {
@@ -1684,10 +1686,13 @@ function behavesLikeRibbonOptionsVault(params: {
           processed: processed1,
           round: round1,
           amount: amount1,
+          unredeemedShares: unredeemedShares1,
         } = await vault.depositReceipts(manager);
         assert.isTrue(processed1);
         assert.equal(round1, 1);
-        assert.bnEqual(amount1, params.depositAmount);
+        assert.bnEqual(amount1, BigNumber.from(0));
+        assert.bnEqual(unredeemedShares1, BigNumber.from(0));
+        assert.bnEqual(await vault.balanceOf(manager), params.depositAmount);
 
         // User deposit in round 2 so no loss
         // we should use the pps after the loss which is the lower pps
@@ -1700,10 +1705,16 @@ function behavesLikeRibbonOptionsVault(params: {
           processed: processed2,
           round: round2,
           amount: amount2,
+          unredeemedShares: unredeemedShares2,
         } = await vault.depositReceipts(user);
         assert.isTrue(processed2);
         assert.equal(round2, 2);
-        assert.bnEqual(amount2, params.depositAmount);
+        assert.bnEqual(amount2, BigNumber.from(0));
+        assert.bnEqual(unredeemedShares2, BigNumber.from(0));
+        assert.bnEqual(
+          await vault.balanceOf(user),
+          expectedMintAmountAfterLoss
+        );
       });
     });
 
@@ -1768,7 +1779,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         assert.isTrue(processed1);
         assert.equal(round1, 1);
-        assert.bnEqual(amount1, depositAmount);
+        assert.bnEqual(amount1, BigNumber.from(0));
         assert.bnEqual(unredeemedShares1, depositAmount.sub(redeemAmount));
 
         const tx2 = await vault.redeem(depositAmount.sub(redeemAmount));
@@ -1786,7 +1797,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         assert.isTrue(processed2);
         assert.equal(round2, 1);
-        assert.bnEqual(amount2, depositAmount);
+        assert.bnEqual(amount2, BigNumber.from(0));
         assert.bnEqual(unredeemedShares2, BigNumber.from(0));
       });
     });

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1552,7 +1552,7 @@ function behavesLikeRibbonOptionsVault(params: {
       });
     });
 
-    describe("#redeem", () => {
+    describe("#maxRedeem", () => {
       let oracle: Contract;
 
       time.revertToSnapshotAfterEach(async function () {
@@ -1568,7 +1568,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const tx = await vault.redeem(params.depositAmount);
+        const tx = await vault.maxRedeem();
 
         assert.bnEqual(
           await assetContract.balanceOf(vault.address),
@@ -1597,11 +1597,9 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        await vault.redeem(params.depositAmount);
+        await vault.maxRedeem();
 
-        await expect(vault.redeem(depositAmount)).to.be.revertedWith(
-          "Processed"
-        );
+        await expect(vault.maxRedeem()).to.be.revertedWith("Processed");
       });
 
       it("reverts when redeeming after implicit redemption", async function () {
@@ -1615,9 +1613,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await vault.deposit(params.depositAmount);
 
-        await expect(vault.redeem(depositAmount)).to.be.revertedWith(
-          "Round not closed"
-        );
+        await expect(vault.maxRedeem()).to.be.revertedWith("Round not closed");
       });
 
       it("is able to redeem deposit at correct pricePerShare after closing short in the money", async function () {
@@ -1683,7 +1679,7 @@ function behavesLikeRibbonOptionsVault(params: {
         // Manager should lose money
         // User should not lose money
         // Manager redeems the deposit from round 1 so there is a loss from ITM options
-        const tx1 = await vault.connect(managerSigner).redeem(depositAmount);
+        const tx1 = await vault.connect(managerSigner).maxRedeem();
         await expect(tx1)
           .to.emit(vault, "Redeem")
           .withArgs(manager, params.depositAmount, 1);
@@ -1699,19 +1695,19 @@ function behavesLikeRibbonOptionsVault(params: {
 
         // User deposit in round 2 so no loss
         // we should use the pps after the loss which is the lower pps
-        const tx2 = await vault.connect(userSigner).redeem(depositAmount);
+        const tx2 = await vault.connect(userSigner).maxRedeem();
         await expect(tx2)
           .to.emit(vault, "Redeem")
           .withArgs(user, expectedMintAmountAfterLoss, 2);
 
-        // const {
-        //   processed: processed2,
-        //   round: round2,
-        //   amount: amount2,
-        // } = await vault.depositReceipts(user);
-        // assert.isTrue(processed2);
-        // assert.equal(round2, 2);
-        // assert.bnEqual(amount2, params.depositAmount);
+        const {
+          processed: processed2,
+          round: round2,
+          amount: amount2,
+        } = await vault.depositReceipts(user);
+        assert.isTrue(processed2);
+        assert.equal(round2, 2);
+        assert.bnEqual(amount2, params.depositAmount);
       });
     });
 

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1595,7 +1595,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await vault.maxRedeem();
 
-        await expect(vault.maxRedeem()).to.be.revertedWith("Processed");
+        await expect(vault.maxRedeem()).to.be.revertedWith("!shares");
       });
 
       it("reverts when redeeming after implicit redemption", async function () {
@@ -1744,19 +1744,41 @@ function behavesLikeRibbonOptionsVault(params: {
         await rollToNextOption();
 
         const redeemAmount = BigNumber.from(1);
-        const tx = await vault.redeem(redeemAmount);
+        const tx1 = await vault.redeem(redeemAmount);
 
-        await expect(tx)
+        await expect(tx1)
           .to.emit(vault, "Redeem")
           .withArgs(user, redeemAmount, 1);
 
-        const { processed, round, amount, unredeemedShares } =
-          await vault.depositReceipts(user);
+        const {
+          processed: processed1,
+          round: round1,
+          amount: amount1,
+          unredeemedShares: unredeemedShares1,
+        } = await vault.depositReceipts(user);
 
-        assert.isTrue(processed);
-        assert.equal(round, 1);
-        assert.bnEqual(amount, depositAmount);
-        assert.bnEqual(unredeemedShares, depositAmount.sub(redeemAmount));
+        assert.isTrue(processed1);
+        assert.equal(round1, 1);
+        assert.bnEqual(amount1, depositAmount);
+        assert.bnEqual(unredeemedShares1, depositAmount.sub(redeemAmount));
+
+        const tx2 = await vault.redeem(depositAmount.sub(redeemAmount));
+
+        await expect(tx2)
+          .to.emit(vault, "Redeem")
+          .withArgs(user, depositAmount.sub(redeemAmount), 1);
+
+        const {
+          processed: processed2,
+          round: round2,
+          amount: amount2,
+          unredeemedShares: unredeemedShares2,
+        } = await vault.depositReceipts(user);
+
+        assert.isTrue(processed2);
+        assert.equal(round2, 1);
+        assert.bnEqual(amount2, depositAmount);
+        assert.bnEqual(unredeemedShares2, BigNumber.from(0));
       });
     });
 

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1710,6 +1710,15 @@ function behavesLikeRibbonOptionsVault(params: {
     describe("#redeem", () => {
       time.revertToSnapshotAfterEach();
 
+      it("reverts when 0 passed", async function () {
+        await assetContract
+          .connect(userSigner)
+          .approve(vault.address, depositAmount);
+        await vault.deposit(depositAmount);
+        await rollToNextOption();
+        await expect(vault.redeem(0)).to.be.revertedWith("!shares");
+      });
+
       it("overflows when shares >uint104", async function () {
         const redeemAmount = BigNumber.from(
           "340282366920938463463374607431768211455"

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -979,7 +979,7 @@ function behavesLikeRibbonOptionsVault(params: {
         assert.bnEqual(amount2, params.depositAmount);
         assert.bnEqual(unredeemedShares2, BigNumber.from(0));
 
-        const tx = await vault.deposit(params.depositAmount);
+        await vault.deposit(params.depositAmount);
 
         assert.bnEqual(
           await assetContract.balanceOf(vault.address),

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -2151,6 +2151,32 @@ function behavesLikeRibbonOptionsVault(params: {
       });
     });
 
+    describe("#shares", () => {
+      it("shows correct share balance after redemptions", async function () {
+        await assetContract
+          .connect(userSigner)
+          .approve(vault.address, depositAmount);
+        await vault.deposit(depositAmount);
+
+        await rollToNextOption();
+
+        const redeemAmount = BigNumber.from(1);
+        await vault.redeem(redeemAmount);
+
+        // Share balance should remain the same because the 1 share
+        // is transferred to the user
+        assert.bnEqual(await vault.shares(user), depositAmount);
+
+        await vault.transfer(manager, redeemAmount);
+
+        assert.bnEqual(
+          await vault.shares(user),
+          depositAmount.sub(redeemAmount)
+        );
+        assert.bnEqual(await vault.shares(manager), redeemAmount);
+      });
+    });
+
     describe("#currentOptionExpiry", () => {
       it("should return 0 when currentOption not set", async function () {
         assert.equal((await vault.currentOptionExpiry()).toString(), "0");

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1552,7 +1552,7 @@ function behavesLikeRibbonOptionsVault(params: {
       });
     });
 
-    describe("#redeemDeposit", () => {
+    describe("#redeem", () => {
       let oracle: Contract;
 
       time.revertToSnapshotAfterEach(async function () {
@@ -1568,7 +1568,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const tx = await vault.redeemDeposit();
+        const tx = await vault.redeem(params.depositAmount);
 
         assert.bnEqual(
           await assetContract.balanceOf(vault.address),
@@ -1597,9 +1597,11 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        await vault.redeemDeposit();
+        await vault.redeem(params.depositAmount);
 
-        await expect(vault.redeemDeposit()).to.be.revertedWith("Processed");
+        await expect(vault.redeem(depositAmount)).to.be.revertedWith(
+          "Processed"
+        );
       });
 
       it("reverts when redeeming after implicit redemption", async function () {
@@ -1613,7 +1615,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await vault.deposit(params.depositAmount);
 
-        await expect(vault.redeemDeposit()).to.be.revertedWith(
+        await expect(vault.redeem(depositAmount)).to.be.revertedWith(
           "Round not closed"
         );
       });
@@ -1681,7 +1683,7 @@ function behavesLikeRibbonOptionsVault(params: {
         // Manager should lose money
         // User should not lose money
         // Manager redeems the deposit from round 1 so there is a loss from ITM options
-        const tx1 = await vault.connect(managerSigner).redeemDeposit();
+        const tx1 = await vault.connect(managerSigner).redeem(depositAmount);
         await expect(tx1)
           .to.emit(vault, "Redeem")
           .withArgs(manager, params.depositAmount, 1);
@@ -1697,19 +1699,19 @@ function behavesLikeRibbonOptionsVault(params: {
 
         // User deposit in round 2 so no loss
         // we should use the pps after the loss which is the lower pps
-        const tx2 = await vault.connect(userSigner).redeemDeposit();
+        const tx2 = await vault.connect(userSigner).redeem(depositAmount);
         await expect(tx2)
           .to.emit(vault, "Redeem")
           .withArgs(user, expectedMintAmountAfterLoss, 2);
 
-        const {
-          processed: processed2,
-          round: round2,
-          amount: amount2,
-        } = await vault.depositReceipts(user);
-        assert.isTrue(processed2);
-        assert.equal(round2, 2);
-        assert.bnEqual(amount2, params.depositAmount);
+        // const {
+        //   processed: processed2,
+        //   round: round2,
+        //   amount: amount2,
+        // } = await vault.depositReceipts(user);
+        // assert.isTrue(processed2);
+        // assert.equal(round2, 2);
+        // assert.bnEqual(amount2, params.depositAmount);
       });
     });
 

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -2152,6 +2152,8 @@ function behavesLikeRibbonOptionsVault(params: {
     });
 
     describe("#shares", () => {
+      time.revertToSnapshotAfterEach();
+
       it("shows correct share balance after redemptions", async function () {
         await assetContract
           .connect(userSigner)
@@ -2159,6 +2161,8 @@ function behavesLikeRibbonOptionsVault(params: {
         await vault.deposit(depositAmount);
 
         await rollToNextOption();
+
+        assert.bnEqual(await vault.shares(user), depositAmount);
 
         const redeemAmount = BigNumber.from(1);
         await vault.redeem(redeemAmount);

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -951,7 +951,7 @@ function behavesLikeRibbonOptionsVault(params: {
         ).to.be.revertedWith("Insufficient balance");
       });
 
-      it("is able to redeem implicitly when the user deposits in a following round [ @skip-on-coverage ]", async function () {
+      it("updates the previous deposit receipt", async function () {
         await assetContract
           .connect(userSigner)
           .approve(vault.address, params.depositAmount.mul(2));
@@ -986,8 +986,6 @@ function behavesLikeRibbonOptionsVault(params: {
           await assetContract.balanceOf(vault.address),
           params.depositAmount
         );
-        // Should redeem the first deposit
-        assert.bnEqual(await vault.balanceOf(user), params.depositAmount);
         assert.bnEqual(await vault.balanceOf(vault.address), BigNumber.from(0));
 
         const {
@@ -1742,7 +1740,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        await vault.redeemDeposit();
+        await vault.maxRedeem();
 
         await expect(
           vault.withdrawInstantly(depositAmount.add(1))


### PR DESCRIPTION
This PR changes the model of how we handle redemptions. Previously we did an implicit redemption that transfers the users shares when they do a new deposit.

Instead of transferring tokens implicitly (which would be an accounting mess), we would track their unredeemed share balance on `DepositReceipt.unredeemedShares`.

We are changing it to:
1. User deposits into vault
2. Vault is rolled, mints shares and holds it on its balance.
3. When the user creates a new deposit, the `unredeemedShares` is updated to include the previous round's `amount`.

Changes include:
* Remove implicit redemption in `deposit`
* `redeem` and `maxRedeem` functions
* `shares` getter that gives the user's share balance, inclusive of what is owed to them (used by FE)
* Removed unused dead code