### PR TITLE
fix decimal compatibility

### DIFF
--- a/contracts/interfaces/IGnosisAuction.sol
+++ b/contracts/interfaces/IGnosisAuction.sol
@@ -1,5 +1,27 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.7.3;
+pragma experimental ABIEncoderV2;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+library AuctionType {
+    struct AuctionData {
+        IERC20 auctioningToken;
+        IERC20 biddingToken;
+        uint256 orderCancellationEndDate;
+        uint256 auctionEndDate;
+        bytes32 initialAuctionOrder;
+        uint256 minimumBiddingAmountPerOrder;
+        uint256 interimSumBidAmount;
+        bytes32 interimOrder;
+        bytes32 clearingPriceOrder;
+        uint96 volumeClearingPriceOrder;
+        bool minFundingThresholdNotReached;
+        bool isAtomicClosureAllowed;
+        uint256 feeNumerator;
+        uint256 minFundingThreshold;
+    }
+}
 
 interface IGnosisAuction {
     function initiateAuction(
@@ -17,6 +39,21 @@ interface IGnosisAuction {
     ) external returns (uint256);
 
     function auctionCounter() external view returns (uint256);
+
+    function auctionData(uint256 auctionId)
+        external
+        view
+        returns (AuctionType.AuctionData memory);
+
+    function auctionAccessManager(uint256 auctionId)
+        external
+        view
+        returns (address);
+
+    function auctionAccessData(uint256 auctionId)
+        external
+        view
+        returns (bytes memory);
 
     function FEE_DENOMINATOR() external view returns (uint256);
 

--- a/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/interfaces/IPriceOracle.sol
@@ -1,0 +1,8 @@
+//SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.7.3;
+
+interface IPriceOracle {
+    function decimals() external view returns (uint256 decimals);
+
+    function latestAnswer() external view returns (uint256 price);
+}

--- a/contracts/interfaces/IRibbon.sol
+++ b/contracts/interfaces/IRibbon.sol
@@ -23,4 +23,6 @@ interface IOptionsPremiumPricer {
         returns (uint256 delta);
 
     function getUnderlyingPrice() external view returns (uint256 price);
+
+    function priceOracle() external view returns (address oracle);
 }

--- a/contracts/libraries/GnosisAuction.sol
+++ b/contracts/libraries/GnosisAuction.sol
@@ -58,7 +58,7 @@ library GnosisAuction {
         // shift decimals to correspond to decimals of USDC for puts
         // and underlying for calls
         uint256 minBidAmount =
-            dswmul(oTokenSellAmount.mul(10**12), auctionDetails.oTokenPremium)
+            dswmul(oTokenSellAmount.mul(10**10), auctionDetails.oTokenPremium)
                 .div(10**(uint256(18).sub(auctionDetails.assetDecimals)));
 
         require(

--- a/contracts/libraries/GnosisAuction.sol
+++ b/contracts/libraries/GnosisAuction.sol
@@ -116,6 +116,7 @@ library GnosisAuction {
 
     function getOTokenPremium(
         address oTokenAddress,
+        address asset,
         address optionsPremiumPricer,
         uint256 premiumDiscount
     ) internal view returns (uint256 optionPremium) {
@@ -129,7 +130,8 @@ library GnosisAuction {
             newOToken.isPut()
         )
             .mul(premiumDiscount)
-            .div(1000);
+            .div(1000)
+            .div(10**uint256(18).sub(IERC20(asset).decimals()));
 
         require(
             optionPremium <= type(uint96).max,

--- a/contracts/libraries/GnosisAuction.sol
+++ b/contracts/libraries/GnosisAuction.sol
@@ -116,9 +116,9 @@ library GnosisAuction {
 
     function getOTokenPremium(
         address oTokenAddress,
-        address asset,
         address optionsPremiumPricer,
-        uint256 premiumDiscount
+        uint256 premiumDiscount,
+        uint256 assetDecimals
     ) internal view returns (uint256 optionPremium) {
         IOtoken newOToken = IOtoken(oTokenAddress);
         // Apply black-scholes formula (from rvol library) to option given its features
@@ -131,7 +131,7 @@ library GnosisAuction {
         )
             .mul(premiumDiscount)
             .div(1000)
-            .div(10**uint256(18).sub(IERC20(asset).decimals()));
+            .div(10**(uint256(18).sub(assetDecimals)));
 
         require(
             optionPremium <= type(uint96).max,

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -85,9 +85,9 @@ library VaultLifecycle {
 
         premium = GnosisAuction.getOTokenPremium(
             otokenAddress,
-            vaultParams.asset,
             vaultParams.optionsPremiumPricer,
-            vaultState.premiumDiscount
+            vaultState.premiumDiscount,
+            vaultParams.decimals
         );
 
         require(premium > 0, "!premium");

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -85,6 +85,7 @@ library VaultLifecycle {
 
         premium = GnosisAuction.getOTokenPremium(
             otokenAddress,
+            vaultParams.asset,
             vaultParams.optionsPremiumPricer,
             vaultState.premiumDiscount
         );

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -86,8 +86,7 @@ library VaultLifecycle {
         premium = GnosisAuction.getOTokenPremium(
             otokenAddress,
             vaultParams.optionsPremiumPricer,
-            vaultState.premiumDiscount,
-            vaultParams.decimals
+            vaultState.premiumDiscount
         );
 
         require(premium > 0, "!premium");

--- a/contracts/tests/MockOptionsPremiumPricer.sol
+++ b/contracts/tests/MockOptionsPremiumPricer.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.7.3;
 contract MockOptionsPremiumPricer {
     uint256 private _optionPremiumPrice;
     uint256 private _optionUnderlyingPrice;
+    uint256 private _optionUSDCPrice;
+    address private _priceOracle;
     mapping(uint256 => uint256) private _deltas;
 
     function getPremium(
@@ -26,6 +28,10 @@ contract MockOptionsPremiumPricer {
         return _optionUnderlyingPrice;
     }
 
+    function priceOracle() external view returns (address) {
+        return _priceOracle;
+    }
+
     function setPremium(uint256 premium) external {
         _optionPremiumPrice = premium;
     }
@@ -36,5 +42,9 @@ contract MockOptionsPremiumPricer {
 
     function setOptionDelta(uint256 strikePrice, uint256 delta) external {
         _deltas[strikePrice] = delta;
+    }
+
+    function setPriceOracle(address priceOracle) external {
+        _priceOracle = priceOracle;
     }
 }

--- a/contracts/tests/MockPriceOracle.sol
+++ b/contracts/tests/MockPriceOracle.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.3;
+
+contract MockPriceOracle {
+    uint256 private _decimals;
+
+    function setDecimals(uint256 decimals) external {
+        _decimals = decimals;
+    }
+
+    function decimals() external view returns (uint256) {
+        return _decimals;
+    }
+}

--- a/contracts/utils/StrikeSelection.sol
+++ b/contracts/utils/StrikeSelection.sol
@@ -39,20 +39,17 @@ contract StrikeSelection is DSMath, Ownable {
         optionsPremiumPricer = IOptionsPremiumPricer(_optionsPremiumPricer);
         // ex: delta = 10
         delta = _delta;
-        // ex: step = 1000
-        step = _step.mul(
-            10 **
-                IPriceOracle(
-                    IOptionsPremiumPricer(_optionsPremiumPricer).priceOracle()
-                )
-                    .decimals()
-        );
-        assetOracleMultiplier =
+        uint256 _assetOracleMultiplier =
             10 **
                 IPriceOracle(
                     IOptionsPremiumPricer(_optionsPremiumPricer).priceOracle()
                 )
                     .decimals();
+
+        // ex: step = 1000
+        step = _step.mul(_assetOracleMultiplier);
+
+        assetOracleMultiplier = _assetOracleMultiplier;
     }
 
     /**

--- a/contracts/utils/StrikeSelection.sol
+++ b/contracts/utils/StrikeSelection.sol
@@ -17,7 +17,7 @@ contract StrikeSelection is DSMath, Ownable {
      */
     IOptionsPremiumPricer public immutable optionsPremiumPricer;
 
-    // delta for options strike price selection (ex: 1 is 100)
+    // delta for options strike price selection. 1 is 10000
     uint256 public delta;
     // step in absolute terms at which we will increment
     // (ex: 100 * 10 ** assetOracleDecimals means we will move at increments of 100 points)
@@ -37,7 +37,7 @@ contract StrikeSelection is DSMath, Ownable {
         require(_delta > 0, "!_delta");
         require(_step > 0, "!_step");
         optionsPremiumPricer = IOptionsPremiumPricer(_optionsPremiumPricer);
-        // ex: delta = 10
+        // ex: delta = 7500 (.75)
         delta = _delta;
         uint256 _assetOracleMultiplier =
             10 **
@@ -78,8 +78,8 @@ contract StrikeSelection is DSMath, Ownable {
         //        return strike price
 
         uint256 strike = assetPrice.sub(assetPrice % step);
-        uint256 targetDelta = isPut ? uint256(100).sub(delta) : delta;
-        uint256 prevDelta = 100;
+        uint256 targetDelta = isPut ? uint256(10000).sub(delta) : delta;
+        uint256 prevDelta = 10000;
 
         while (true) {
             uint256 currDelta =

--- a/contracts/utils/StrikeSelection.sol
+++ b/contracts/utils/StrikeSelection.sol
@@ -71,7 +71,10 @@ contract StrikeSelection is DSMath, Ownable {
 
         while (true) {
             uint256 currDelta =
-                optionsPremiumPricer.getOptionDelta(strike, expiryTimestamp);
+                optionsPremiumPricer.getOptionDelta(
+                    strike.mul(10**8),
+                    expiryTimestamp
+                );
 
             //  If the current delta is between the previous
             //  strike price delta and current strike price delta

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -523,6 +523,7 @@ contract RibbonThetaVault is OptionsVaultStorage {
         auctionDetails.oTokenAddress = optionState.currentOption;
         auctionDetails.gnosisEasyAuction = GNOSIS_EASY_AUCTION;
         auctionDetails.asset = vaultParams.asset;
+        auctionDetails.assetDecimals = vaultParams.decimals;
         auctionDetails.oTokenPremium = currentOtokenPremium;
         auctionDetails.manager = owner();
         auctionDetails.duration = 6 hours;

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1050,7 +1050,10 @@ function behavesLikeRibbonOptionsVault(params: {
 
         assert.bnEqual(
           vaultState.currentOtokenPremium,
-          params.premium.mul(vaultState.premiumDiscount).div(1000)
+          params.premium
+            .mul(vaultState.premiumDiscount)
+            .div(1000)
+            .mul(BigNumber.from(10).pow(12))
         );
       });
 
@@ -1076,7 +1079,11 @@ function behavesLikeRibbonOptionsVault(params: {
 
         assert.equal(
           vaultState.currentOtokenPremium.toString(),
-          params.premium.mul(vaultState.premiumDiscount).div(1000).toString()
+          params.premium
+            .mul(vaultState.premiumDiscount)
+            .div(1000)
+            .mul(BigNumber.from(10).pow(12))
+            .toString()
         );
       });
 

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -2,6 +2,7 @@ import { ethers } from "hardhat";
 import { expect } from "chai";
 import { BigNumber, BigNumberish, constants, Contract } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
+
 import moment from "moment-timezone";
 import * as time from "./helpers/time";
 import {
@@ -24,7 +25,9 @@ import {
   whitelistProduct,
   mintToken,
   bidForOToken,
+  decodeOrder,
 } from "./helpers/utils";
+import { wdiv, wmul } from "./helpers/math";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { assert } from "./helpers/assertions";
 
@@ -246,8 +249,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
       await optionsPremiumPricer.setPremium(
         params.premium
-          .mul(BigNumber.from(10).pow(18))
-          .div(BigNumber.from(10).pow(params.tokenDecimals))
+          .mul(BigNumber.from(10).pow(18 - params.tokenDecimals))
           .toString()
       );
 
@@ -438,8 +440,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
       await optionsPremiumPricer.setPremium(
         params.premium
-          .mul(BigNumber.from(10).pow(18))
-          .div(BigNumber.from(10).pow(params.tokenDecimals))
+          .mul(BigNumber.from(10).pow(18 - params.tokenDecimals))
           .toString()
       );
 
@@ -1124,27 +1125,33 @@ function behavesLikeRibbonOptionsVault(params: {
           await weth.deposit({ value: premium });
           return;
         }
+      });
 
+      it("reverts when not called with owner", async function () {
         await vault.connect(ownerSigner).commitAndClose();
 
         await time.increaseTo((await getNextOptionReadyAt()) + 1);
 
         await vault.connect(ownerSigner).rollToNextOption();
-      });
 
-      it("reverts when not called with owner", async function () {
         await expect(
           vault.connect(userSigner).burnRemainingOTokens()
         ).to.be.revertedWith("Ownable: caller is not the owner");
       });
 
       it("reverts when trying to burn 0 OTokens", async function () {
+        await vault.connect(ownerSigner).commitAndClose();
+
+        await time.increaseTo((await getNextOptionReadyAt()) + 1);
+
+        await vault.connect(ownerSigner).rollToNextOption();
+
         const auctionDetails = await bidForOToken(
           gnosisAuction,
           optionsPremiumPricer,
           assetContract,
           userSigner.address,
-          defaultOtokenAddress,
+          params.expectedMintAmount,
           params.premium,
           "1"
         );
@@ -1159,12 +1166,18 @@ function behavesLikeRibbonOptionsVault(params: {
       });
 
       it("burns all remaining oTokens", async function () {
+        await vault.connect(ownerSigner).commitAndClose();
+
+        await time.increaseTo((await getNextOptionReadyAt()) + 1);
+
+        await vault.connect(ownerSigner).rollToNextOption();
+
         const auctionDetails = await bidForOToken(
           gnosisAuction,
           optionsPremiumPricer,
           assetContract,
           userSigner.address,
-          defaultOtokenAddress,
+          params.expectedMintAmount,
           params.premium,
           "2"
         );
@@ -1264,6 +1277,79 @@ function behavesLikeRibbonOptionsVault(params: {
         );
 
         assert.equal(await vault.currentOption(), defaultOtokenAddress);
+      });
+
+      it("starts auction with correct parameters", async function () {
+        await vault.connect(ownerSigner).commitAndClose();
+
+        await time.increaseTo((await vault.nextOptionReadyAt()).toNumber() + 1);
+
+        const res = vault.connect(ownerSigner).rollToNextOption();
+
+        const currentAuctionCounter = await gnosisAuction.auctionCounter();
+        const auctionDetails = await gnosisAuction.auctionData(
+          currentAuctionCounter.toString()
+        );
+        const feeNumerator = await gnosisAuction.feeNumerator();
+        const feeDenominator = await gnosisAuction.FEE_DENOMINATOR();
+
+        assert.equal(auctionDetails.auctioningToken, defaultOtokenAddress);
+        assert.equal(auctionDetails.biddingToken, collateralAsset);
+        assert.equal(
+          auctionDetails.orderCancellationEndDate.toString(),
+          (await time.now()).add(10800).toString()
+        );
+        assert.equal(
+          auctionDetails.auctionEndDate.toString(),
+          (await time.now()).add(21600).toString()
+        );
+        assert.equal(
+          auctionDetails.minimumBiddingAmountPerOrder.toString(),
+          "1"
+        );
+        assert.equal(auctionDetails.isAtomicClosureAllowed, false);
+        assert.equal(
+          auctionDetails.feeNumerator.toString(),
+          feeNumerator.toString()
+        );
+        assert.equal(auctionDetails.minFundingThreshold.toString(), "0");
+        assert.equal(
+          await gnosisAuction.auctionAccessManager(currentAuctionCounter),
+          ownerSigner.address
+        );
+        assert.equal(
+          await gnosisAuction.auctionAccessData(currentAuctionCounter),
+          "0x"
+        );
+
+        const initialAuctionOrder = decodeOrder(
+          auctionDetails.initialAuctionOrder
+        );
+        const oTokenSellAmount = params.expectedMintAmount
+          .mul(feeDenominator)
+          .div(feeDenominator.add(feeNumerator));
+        const oTokenPremium = (
+          await optionsPremiumPricer.getPremium(0, 0, true)
+        )
+          .mul((await vault.vaultState()).premiumDiscount)
+          .div(1000);
+        assert.equal(
+          initialAuctionOrder.sellAmount.toString(),
+          oTokenSellAmount.toString()
+        );
+        assert.equal(
+          initialAuctionOrder.buyAmount.toString(),
+          wmul(oTokenSellAmount.mul(BigNumber.from(10).pow(10)), oTokenPremium)
+            .div(BigNumber.from(10).pow(18 - tokenDecimals))
+            .toString()
+        );
+
+        // Hardcoded
+        // assert.equal(auctionDetails.interimSumBidAmount, 0);
+        // assert.equal(auctionDetails.interimOrder, IterableOrderedOrderSet.QUEUE_START);
+        // assert.equal(auctionDetails.clearingPriceOrder, bytes32(0));
+        // assert.equal(auctionDetails.volumeClearingPriceOrder, 0);
+        // assert.equal(auctionDetails.minFundingThresholdNotReached, false);
       });
 
       it("reverts when calling before expiry", async function () {

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1050,10 +1050,9 @@ function behavesLikeRibbonOptionsVault(params: {
 
         assert.bnEqual(
           vaultState.currentOtokenPremium,
-          params.premium
+          (await optionsPremiumPricer.getPremium(0, 0, true))
             .mul(vaultState.premiumDiscount)
             .div(1000)
-            .mul(BigNumber.from(10).pow(12))
         );
       });
 
@@ -1079,10 +1078,9 @@ function behavesLikeRibbonOptionsVault(params: {
 
         assert.equal(
           vaultState.currentOtokenPremium.toString(),
-          params.premium
+          (await optionsPremiumPricer.getPremium(0, 0, true))
             .mul(vaultState.premiumDiscount)
             .div(1000)
-            .mul(BigNumber.from(10).pow(12))
             .toString()
         );
       });

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -244,7 +244,12 @@ function behavesLikeRibbonOptionsVault(params: {
         parseUnits(params.firstOptionStrike.toString(), 8)
       );
 
-      await optionsPremiumPricer.setPremium(params.premium.toString());
+      await optionsPremiumPricer.setPremium(
+        params.premium
+          .mul(BigNumber.from(10).pow(18))
+          .div(BigNumber.from(10).pow(params.tokenDecimals))
+          .toString()
+      );
 
       await vault.connect(ownerSigner).commitAndClose();
       await time.increaseTo((await getNextOptionReadyAt()) + 1);
@@ -414,7 +419,12 @@ function behavesLikeRibbonOptionsVault(params: {
         .connect(ownerSigner)
         .setPremiumDiscount(params.premiumDiscount);
 
-      await optionsPremiumPricer.setPremium(params.premium.toString());
+      await optionsPremiumPricer.setPremium(
+        params.premium
+          .mul(BigNumber.from(10).pow(18))
+          .div(BigNumber.from(10).pow(params.tokenDecimals))
+          .toString()
+      );
 
       defaultOtokenAddress = firstOption.address;
       defaultOtoken = await getContractAt("IERC20", defaultOtokenAddress);

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -27,7 +27,7 @@ import {
   bidForOToken,
   decodeOrder,
 } from "./helpers/utils";
-import { wdiv, wmul } from "./helpers/math";
+import { wmul } from "./helpers/math";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { assert } from "./helpers/assertions";
 
@@ -1284,7 +1284,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await time.increaseTo((await vault.nextOptionReadyAt()).toNumber() + 1);
 
-        const res = vault.connect(ownerSigner).rollToNextOption();
+        await vault.connect(ownerSigner).rollToNextOption();
 
         const currentAuctionCounter = await gnosisAuction.auctionCounter();
         const auctionDetails = await gnosisAuction.auctionData(

--- a/test/StrikeSelection.ts
+++ b/test/StrikeSelection.ts
@@ -37,7 +37,7 @@ describe("StrikeSelection", () => {
 
     strikeSelection = await StrikeSelection.deploy(
       mockOptionsPremiumPricer.address,
-      10,
+      1000,
       100
     );
   });
@@ -47,13 +47,13 @@ describe("StrikeSelection", () => {
 
     it("reverts when not owner call", async function () {
       await expect(
-        strikeSelection.connect(signer2).setDelta(50)
+        strikeSelection.connect(signer2).setDelta(5000)
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("sets the delta", async function () {
-      await strikeSelection.connect(signer).setDelta(50);
-      assert.equal((await strikeSelection.delta()).toString(), "50");
+      await strikeSelection.connect(signer).setDelta(5000);
+      assert.equal((await strikeSelection.delta()).toString(), "5000");
     });
   });
 
@@ -81,12 +81,12 @@ describe("StrikeSelection", () => {
     time.revertToSnapshotAfterEach();
 
     let underlyingPrice: BigNumber;
-    let deltaAtUnderlying = BigNumber.from(50);
+    let deltaAtUnderlying = BigNumber.from(5000);
 
     beforeEach(async () => {
       underlyingPrice = await mockOptionsPremiumPricer.getUnderlyingPrice();
 
-      let delta = 100;
+      let delta = 10000;
       for (let i = -1000; i < 1100; i += 100) {
         await mockOptionsPremiumPricer.setOptionDelta(
           underlyingPrice.add(
@@ -96,7 +96,7 @@ describe("StrikeSelection", () => {
           ),
           delta
         );
-        delta -= 5;
+        delta -= 500;
       }
     });
 
@@ -130,7 +130,7 @@ describe("StrikeSelection", () => {
           .add(
             deltaAtUnderlying
               .sub(targetDelta)
-              .div(5)
+              .div(500)
               .mul(100)
               .mul(BigNumber.from(10).pow(await mockPriceOracle.decimals()))
           )
@@ -153,7 +153,7 @@ describe("StrikeSelection", () => {
           .add(
             deltaAtUnderlying
               .sub(targetDelta)
-              .div(5)
+              .div(500)
               .mul(100)
               .mul(BigNumber.from(10).pow(await mockPriceOracle.decimals()))
           )
@@ -176,14 +176,14 @@ describe("StrikeSelection", () => {
           .sub(
             deltaAtUnderlying
               .sub(targetDelta)
-              .div(5)
+              .div(500)
               .mul(100)
               .mul(BigNumber.from(10).pow(await mockPriceOracle.decimals()))
           )
           .toString()
       );
       assert.equal(
-        BigNumber.from(100).sub(delta).toString(),
+        BigNumber.from(10000).sub(delta).toString(),
         targetDelta.toString()
       );
     });

--- a/test/StrikeSelection.ts
+++ b/test/StrikeSelection.ts
@@ -5,7 +5,7 @@ import * as time from "./helpers/time";
 import { BigNumber } from "@ethersproject/bignumber";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
-const { getContractFactory, getContractAt } = ethers;
+const { getContractFactory } = ethers;
 
 describe("StrikeSelection", () => {
   let strikeSelection: Contract;

--- a/test/StrikeSelection.ts
+++ b/test/StrikeSelection.ts
@@ -69,12 +69,14 @@ describe("StrikeSelection", () => {
     let deltaAtUnderlying = BigNumber.from(50);
 
     beforeEach(async () => {
-      underlyingPrice = await mockOptionsPremiumPricer.getUnderlyingPrice();
+      underlyingPrice = (
+        await mockOptionsPremiumPricer.getUnderlyingPrice()
+      ).mul(BigNumber.from(10).pow(8));
 
       let delta = 100;
       for (let i = -1000; i < 1100; i += 100) {
         await mockOptionsPremiumPricer.setOptionDelta(
-          underlyingPrice.add(BigNumber.from(i)),
+          underlyingPrice.add(BigNumber.from(i).mul(BigNumber.from(10).pow(8))),
           delta
         );
         delta -= 5;
@@ -104,7 +106,13 @@ describe("StrikeSelection", () => {
       assert.equal(
         strikePrice.toString(),
         underlyingPrice
-          .add(deltaAtUnderlying.sub(targetDelta).div(5).mul(100)).mul(BigNumber.from(10).pow(8))
+          .add(
+            deltaAtUnderlying
+              .sub(targetDelta)
+              .div(5)
+              .mul(100)
+              .mul(BigNumber.from(10).pow(8))
+          )
           .toString()
       );
       assert.equal(delta.toString(), targetDelta.toString());
@@ -121,7 +129,13 @@ describe("StrikeSelection", () => {
       assert.equal(
         strikePrice.toString(),
         underlyingPrice
-          .add(deltaAtUnderlying.sub(targetDelta).div(5).mul(100)).mul(BigNumber.from(10).pow(8))
+          .add(
+            deltaAtUnderlying
+              .sub(targetDelta)
+              .div(5)
+              .mul(100)
+              .mul(BigNumber.from(10).pow(8))
+          )
           .toString()
       );
       assert.equal(delta.toString(), targetDelta.toString());
@@ -138,7 +152,13 @@ describe("StrikeSelection", () => {
       assert.equal(
         strikePrice.toString(),
         underlyingPrice
-          .sub(deltaAtUnderlying.sub(targetDelta).div(5).mul(100)).mul(BigNumber.from(10).pow(8))
+          .sub(
+            deltaAtUnderlying
+              .sub(targetDelta)
+              .div(5)
+              .mul(100)
+              .mul(BigNumber.from(10).pow(8))
+          )
           .toString()
       );
       assert.equal(

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -211,18 +211,14 @@ export async function bidForOToken(
   optionsPremiumPricer: Contract,
   assetContract: Contract,
   contractSigner: string,
-  oToken: string,
+  mintAmount: BigNumber,
   premium: BigNumberish,
   multiplier: string
 ) {
   const userSigner = await ethers.provider.getSigner(contractSigner);
 
   const latestAuction = (await gnosisAuction.auctionCounter()).toString();
-  const totalOptionsAvailableToBuy = BigNumber.from(
-    await (
-      await ethers.getContractAt("IERC20", oToken)
-    ).balanceOf(gnosisAuction.address)
-  )
+  const totalOptionsAvailableToBuy = mintAmount
     .mul(await gnosisAuction.FEE_DENOMINATOR())
     .div(
       (await gnosisAuction.FEE_DENOMINATOR()).add(
@@ -256,4 +252,18 @@ export async function bidForOToken(
   await increaseTo((await provider.getBlock("latest")).timestamp + 21600);
 
   return [latestAuction, totalOptionsAvailableToBuy, bid];
+}
+
+export interface Order {
+  sellAmount: BigNumber;
+  buyAmount: BigNumber;
+  userId: BigNumber;
+}
+
+export function decodeOrder(bytes: string): Order {
+  return {
+    userId: BigNumber.from("0x" + bytes.substring(2, 18)),
+    sellAmount: BigNumber.from("0x" + bytes.substring(43, 66)),
+    buyAmount: BigNumber.from("0x" + bytes.substring(19, 42)),
+  };
 }


### PR DESCRIPTION
1. shifts decimals of premium in GnosisAuction to be consistent with the bidding token (eth for eth call vaults, usdc for eth put vaults, etc)
3. make step, strike price, asset price in strikeSelection all scaled by 10 ** 8 for consistency with options premium pricer and oToken strikeprice decimals