### PR TITLE
[L01] Numerous uint types and resultant casts increase system complexity

### DIFF
--- a/contracts/libraries/GnosisAuction.sol
+++ b/contracts/libraries/GnosisAuction.sol
@@ -126,7 +126,7 @@ library GnosisAuction {
         // calculate how much to allocate
         sellAmount = bidDetails
             .lockedBalance
-            .mul(bidDetails.optionAllocationPct)
+            .mul(bidDetails.optionAllocation)
             .div(100 * Vault.OPTION_ALLOCATION_DECIMALS);
 
         // divide the `asset` sellAmount by the target premium per oToken to

--- a/contracts/libraries/ShareMath.sol
+++ b/contracts/libraries/ShareMath.sol
@@ -13,35 +13,29 @@ library ShareMath {
     function underlyingToShares(
         uint256 underlyingAmount,
         uint256 pps,
-        uint8 decimals
-    ) internal pure returns (uint104) {
-        // If this throws, it means that vault's roundPricePerShare[currentRound] has not been set yet
-        // which should never happen.
-        // Has to be larger than 1 because `1` is used in `initRoundPricePerShares` to prevent cold writes.
-        require(pps > PLACEHOLDER_UINT, "Invalid pps");
-
-        uint256 shares =
-            uint256(underlyingAmount).mul(10**uint256(decimals)).div(pps);
-        assertUint104(shares);
-
-        return uint104(shares);
-    }
-
-    function sharesToUnderlying(
-        uint256 shares,
-        uint256 pps,
-        uint8 decimals
+        uint256 decimals
     ) internal pure returns (uint256) {
         // If this throws, it means that vault's roundPricePerShare[currentRound] has not been set yet
         // which should never happen.
         // Has to be larger than 1 because `1` is used in `initRoundPricePerShares` to prevent cold writes.
         require(pps > PLACEHOLDER_UINT, "Invalid pps");
 
-        uint256 underlyingAmount =
-            uint256(shares).mul(pps).div(10**uint256(decimals));
-        assertUint104(shares);
+        uint256 shares = uint256(underlyingAmount).mul(10**decimals).div(pps);
 
-        return underlyingAmount;
+        return shares;
+    }
+
+    function sharesToUnderlying(
+        uint256 shares,
+        uint256 pps,
+        uint256 decimals
+    ) internal pure returns (uint256) {
+        // If this throws, it means that vault's roundPricePerShare[currentRound] has not been set yet
+        // which should never happen.
+        // Has to be larger than 1 because `1` is used in `initRoundPricePerShares` to prevent cold writes.
+        require(pps > PLACEHOLDER_UINT, "Invalid pps");
+
+        return shares.mul(pps).div(10**decimals);
     }
 
     /**
@@ -56,8 +50,8 @@ library ShareMath {
         Vault.DepositReceipt memory depositReceipt,
         uint256 currentRound,
         uint256 pps,
-        uint8 decimals
-    ) internal pure returns (uint128 unredeemedShares) {
+        uint256 decimals
+    ) internal pure returns (uint256 unredeemedShares) {
         if (
             depositReceipt.round > 0 &&
             depositReceipt.round < currentRound &&
@@ -66,10 +60,10 @@ library ShareMath {
             uint256 sharesFromRound =
                 underlyingToShares(depositReceipt.amount, pps, decimals);
 
-            uint256 unredeemedShares256 =
+            return
                 uint256(depositReceipt.unredeemedShares).add(sharesFromRound);
         }
-            return depositReceipt.unredeemedShares;
+        return depositReceipt.unredeemedShares;
     }
 
     /************************************************

--- a/contracts/libraries/ShareMath.sol
+++ b/contracts/libraries/ShareMath.sol
@@ -68,12 +68,8 @@ library ShareMath {
 
             uint256 unredeemedShares256 =
                 uint256(depositReceipt.unredeemedShares).add(sharesFromRound);
-            assertUint128(unredeemedShares256);
-
-            unredeemedShares = uint128(unredeemedShares256);
-        } else {
-            unredeemedShares = depositReceipt.unredeemedShares;
         }
+            return depositReceipt.unredeemedShares;
     }
 
     /************************************************

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -27,7 +27,7 @@ library VaultLifecycle {
         address USDC;
         address currentOption;
         uint256 delay;
-        uint16 lastStrikeOverride;
+        uint256 lastStrikeOverride;
         uint256 overriddenStrikePrice;
     }
 

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -119,7 +119,7 @@ library VaultLifecycle {
      */
     function verifyOtoken(
         address otokenAddress,
-        Vault.VaultParams calldata vaultParams,
+        Vault.VaultParams storage vaultParams,
         address collateralAsset,
         address USDC,
         uint256 delay
@@ -506,7 +506,7 @@ library VaultLifecycle {
      */
     function getOrDeployOtoken(
         CloseParams calldata closeParams,
-        Vault.VaultParams calldata vaultParams,
+        Vault.VaultParams storage vaultParams,
         address underlying,
         address collateralAsset,
         uint256 strikePrice,
@@ -601,7 +601,6 @@ library VaultLifecycle {
     /**
      * @notice Verify the constructor params satisfy requirements
      * @param owner is the owner of the vault with critical permissions
-     * @param keeper is the keeper of the vault with medium permissions (weekly actions)
      * @param feeRecipient is the address to recieve vault performance and management fees
      * @param performanceFee is the perfomance fee pct.
      * @param tokenName is the name of the token

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -145,10 +145,10 @@ library VaultLifecycle {
     function rollover(
         uint256 currentSupply,
         address asset,
-        uint8 decimals,
+        uint256 decimals,
         uint256 initialSharePrice,
         uint256 pendingAmount,
-        uint128 queuedWithdrawShares
+        uint256 queuedWithdrawShares
     )
         external
         view
@@ -161,7 +161,7 @@ library VaultLifecycle {
         uint256 currentBalance = IERC20(asset).balanceOf(address(this));
         uint256 roundStartBalance = currentBalance.sub(pendingAmount);
 
-        uint256 singleShare = 10**uint256(decimals);
+        uint256 singleShare = 10**decimals;
 
         newPricePerShare = getPPS(
             currentSupply,
@@ -180,9 +180,7 @@ library VaultLifecycle {
 
         uint256 queuedWithdrawAmount =
             newSupply > 0
-                ? uint256(queuedWithdrawShares).mul(currentBalance).div(
-                    newSupply
-                )
+                ? queuedWithdrawShares.mul(currentBalance).div(newSupply)
                 : 0;
 
         return (

--- a/contracts/storage/RibbonDeltaVaultStorage.sol
+++ b/contracts/storage/RibbonDeltaVaultStorage.sol
@@ -9,7 +9,7 @@ abstract contract RibbonDeltaVaultStorageV1 {
     // % of funds to be used for weekly option purchase
     uint256 public optionAllocationPct;
     // Delta vault equivalent of lockedAmount
-    uint104 public balanceBeforePremium;
+    uint256 public balanceBeforePremium;
     // User Id of delta vault in latest gnosis auction
     Vault.AuctionSellOrder public auctionSellOrder;
 }

--- a/contracts/storage/RibbonThetaVaultStorage.sol
+++ b/contracts/storage/RibbonThetaVaultStorage.sol
@@ -7,13 +7,13 @@ abstract contract RibbonThetaVaultStorageV1 {
     // Logic contract used to select strike prices
     address public strikeSelection;
     // Premium discount on options we are selling (thousandths place: 000 - 999)
-    uint32 public premiumDiscount;
+    uint256 public premiumDiscount;
     // Current oToken premium
-    uint104 public currentOtokenPremium;
+    uint256 public currentOtokenPremium;
     // Last round id at which the strike was manually overridden
-    uint16 public lastStrikeOverride;
+    uint256 public lastStrikeOverride;
     // Price last overridden strike set to
-    uint128 public overriddenStrikePrice;
+    uint256 public overriddenStrikePrice;
     // Auction duration
     uint256 public auctionDuration;
     // Auction id of current option

--- a/contracts/utils/StrikeSelection.sol
+++ b/contracts/utils/StrikeSelection.sol
@@ -167,7 +167,7 @@ contract StrikeSelection is Ownable {
         bool isPut
     ) private pure returns (uint256) {
         uint256 finalDelta;
-        
+
         // for tie breaks (ex: 0.05 <= 0.1 <= 0.15) round to higher strike price
         // for calls and lower strike price for puts for deltas
         if (isPut) {
@@ -183,7 +183,7 @@ contract StrikeSelection is Ownable {
                 ? currDelta
                 : prevDelta;
         }
-        
+
         return finalDelta;
     }
 

--- a/contracts/vaults/RibbonDeltaVault.sol
+++ b/contracts/vaults/RibbonDeltaVault.sol
@@ -373,7 +373,7 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
             // Subtraction underflow checks already ensure it is smaller than uint104
             depositReceipt.amount = uint104(
                 ShareMath.sharesToUnderlying(
-                    uint256(receiptShares).sub(sharesWithdrawn),
+                    receiptShares.sub(sharesWithdrawn),
                     roundPricePerShare[depositReceipt.round],
                     vaultParams.decimals
                 )

--- a/contracts/vaults/RibbonDeltaVault.sol
+++ b/contracts/vaults/RibbonDeltaVault.sol
@@ -282,7 +282,7 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
         optionState.nextOptionReadyAt = uint32(nextOptionReady);
 
         optionState.currentOption = address(0);
-        vaultState.lastLockedAmount = balanceBeforePremium;
+        vaultState.lastLockedAmount = uint104(balanceBeforePremium);
 
         // redeem
         if (oldOption != address(0)) {

--- a/contracts/vaults/RibbonDeltaVault.sol
+++ b/contracts/vaults/RibbonDeltaVault.sol
@@ -93,7 +93,6 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
     /**
      * @notice Initializes the OptionVault contract with storage variables.
      * @param _owner is the owner of the vault with critical permissions
-     * @param _keeper is the keeper of the vault with medium permissions (weekly actions)
      * @param _feeRecipient is the address to recieve vault performance and management fees
      * @param _managementFee is the management fee pct.
      * @param _performanceFee is the perfomance fee pct.
@@ -101,7 +100,7 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
      * @param _tokenSymbol is the symbol of the token
      * @param _counterpartyThetaVault is the address of the counterparty theta
      vault of this delta vault
-     * @param _optionAllocation is the pct of the funds to allocate towards the weekly option
+     * @param _optionAllocationPct is the pct of the funds to allocate towards the weekly option
      * @param _vaultParams is the struct with vault general data
      */
     function initialize(

--- a/contracts/vaults/RibbonDeltaVault.sol
+++ b/contracts/vaults/RibbonDeltaVault.sol
@@ -112,7 +112,7 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
         string memory _tokenName,
         string memory _tokenSymbol,
         address _counterpartyThetaVault,
-        uint256 _optionAllocation,
+        uint256 _optionAllocationPct,
         Vault.VaultParams calldata _vaultParams
     ) external initializer {
         baseInitialize(
@@ -135,12 +135,12 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
         );
         // 1000 = 10%. Needs to be less than 10% of the funds allocated to option.
         require(
-            _optionAllocation > 0 &&
-                _optionAllocation < 10 * Vault.OPTION_ALLOCATION_DECIMALS,
-            "!_optionAllocation"
+            _optionAllocationPct > 0 &&
+                _optionAllocationPct < 10 * Vault.OPTION_ALLOCATION_DECIMALS,
+            "!_optionAllocationPct"
         );
         counterpartyThetaVault = IRibbonThetaVault(_counterpartyThetaVault);
-        optionAllocation = _optionAllocation;
+        optionAllocationPct = _optionAllocationPct;
     }
 
     /**
@@ -186,7 +186,7 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
     /**
      * @notice Sets the new % allocation of funds towards options purchases (2 decimals. ex: 10 * 10**2 is 10%)
      * 0 < newOptionAllocation < 1000. 1000 = 10%.
-     * @param newOptionAllocation is the option % allocation
+     * @param newOptionAllocationPct is the option % allocation
      */
     function setOptionAllocation(uint256 newOptionAllocationPct)
         external
@@ -194,14 +194,17 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
     {
         // Needs to be less than 10%
         require(
-            newOptionAllocation > 0 &&
-                newOptionAllocation < 10 * Vault.OPTION_ALLOCATION_DECIMALS,
+            newOptionAllocationPct > 0 &&
+                newOptionAllocationPct < 10 * Vault.OPTION_ALLOCATION_DECIMALS,
             "Invalid allocation"
         );
 
-        emit NewOptionAllocationSet(optionAllocation, newOptionAllocation);
+        emit NewOptionAllocationSet(
+            optionAllocationPct,
+            newOptionAllocationPct
+        );
 
-        optionAllocation = newOptionAllocation;
+        optionAllocationPct = newOptionAllocationPct;
     }
 
     /************************************************
@@ -319,7 +322,7 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
         bidDetails.asset = vaultParams.asset;
         bidDetails.assetDecimals = vaultParams.decimals;
         bidDetails.lockedBalance = lockedBalance;
-        bidDetails.optionAllocation = optionAllocation;
+        bidDetails.optionAllocation = optionAllocationPct;
         bidDetails.optionPremium = optionPremium;
         bidDetails.bidder = msg.sender;
 

--- a/contracts/vaults/RibbonDeltaVault.sol
+++ b/contracts/vaults/RibbonDeltaVault.sol
@@ -48,7 +48,11 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
         uint256 newOptionAllocation
     );
 
-    event InstantWithdraw(address indexed account, uint256 share, uint16 round);
+    event InstantWithdraw(
+        address indexed account,
+        uint256 share,
+        uint256 round
+    );
 
     event PlaceAuctionBid(
         uint256 auctionId,
@@ -184,7 +188,7 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
      * 0 < newOptionAllocation < 1000. 1000 = 10%.
      * @param newOptionAllocation is the option % allocation
      */
-    function setOptionAllocation(uint16 newOptionAllocation)
+    function setOptionAllocation(uint256 newOptionAllocationPct)
         external
         onlyOwner
     {
@@ -226,6 +230,7 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
                 )
             );
         }
+        uint256 currentRound = vaultState.round;
 
         // If we need to withdraw beyond current round deposit
         if (sharesLeftForWithdrawal > 0) {
@@ -246,12 +251,12 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
             _burn(msg.sender, sharesLeftForWithdrawal);
         }
 
-        emit InstantWithdraw(msg.sender, share, vaultState.round);
+        emit InstantWithdraw(msg.sender, share, currentRound);
 
         uint256 sharesToUnderlying =
             ShareMath.sharesToUnderlying(
                 share,
-                roundPricePerShare[vaultState.round],
+                roundPricePerShare[currentRound],
                 vaultParams.decimals
             );
         transferAsset(msg.sender, sharesToUnderlying);

--- a/contracts/vaults/RibbonDeltaVault.sol
+++ b/contracts/vaults/RibbonDeltaVault.sol
@@ -217,7 +217,7 @@ contract RibbonDeltaVault is RibbonVault, RibbonDeltaVaultStorage {
         updatePPS(true)
         nonReentrant
     {
-        require(share > 0, "!shares");
+        require(share > 0, "!numShares");
 
         (uint256 sharesToWithdrawFromPending, uint256 sharesLeftForWithdrawal) =
             _withdrawFromNewDeposit(share);

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -355,7 +355,7 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
     /**
      * @notice Initiate the gnosis auction.
      */
-    function startAuction() external onlyKeeper nonReentrant {
+    function startAuction() external nonReentrant {
         _startAuction();
     }
 

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -65,7 +65,7 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
     event InstantWithdraw(
         address indexed account,
         uint256 amount,
-        uint16 round
+        uint256 round
     );
 
     event InitiateGnosisAuction(
@@ -245,7 +245,7 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
         Vault.DepositReceipt storage depositReceipt =
             depositReceipts[msg.sender];
 
-        uint16 currentRound = vaultState.round;
+        uint256 currentRound = vaultState.round;
         require(amount > 0, "!amount");
         require(depositReceipt.round == currentRound, "Invalid round");
 

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -168,7 +168,7 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
      * @notice Sets the new discount on premiums for options we are selling
      * @param newPremiumDiscount is the premium discount
      */
-    function setPremiumDiscount(uint16 newPremiumDiscount) external onlyOwner {
+    function setPremiumDiscount(uint256 newPremiumDiscount) external onlyOwner {
         require(
             newPremiumDiscount > 0 &&
                 newPremiumDiscount < 100 * Vault.PREMIUM_DISCOUNT_DECIMALS,

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -249,11 +249,11 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
         require(amount > 0, "!amount");
         require(depositReceipt.round == currentRound, "Invalid round");
 
-        uint104 receiptAmount = depositReceipt.amount;
+        uint256 receiptAmount = depositReceipt.amount;
         require(receiptAmount >= amount, "Exceed amount");
 
         // Subtraction underflow checks already ensure it is smaller than uint104
-        depositReceipt.amount = uint104(uint256(receiptAmount).sub(amount));
+        depositReceipt.amount = uint104(receiptAmount.sub(amount));
         vaultState.totalPending = uint128(
             uint256(vaultState.totalPending).sub(amount)
         );
@@ -316,8 +316,12 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
      */
     function _closeShort(address oldOption) private {
         optionState.currentOption = address(0);
+
         uint256 lockedAmount = vaultState.lockedAmount;
-        vaultState.lastLockedAmount = uint104(lockedAmount);
+        vaultState.lastLockedAmount = lockedAmount > 0
+            ? uint104(lockedAmount)
+            : vaultState.lastLockedAmount;
+
         vaultState.lockedAmount = 0;
 
         if (oldOption != address(0)) {

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -111,7 +111,6 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
     /**
      * @notice Initializes the OptionVault contract with storage variables.
      * @param _owner is the owner of the vault with critical permissions
-     * @param _keeper is the keeper of the vault with medium permissions (weekly actions)
      * @param _feeRecipient is the address to recieve vault performance and management fees
      * @param _managementFee is the management fee pct.
      * @param _performanceFee is the perfomance fee pct.

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -348,6 +348,8 @@ contract RibbonVault is
                 roundPricePerShare[depositReceipt.round],
                 vaultParams.decimals
             );
+        
+        uint256 depositAmount = amount;
 
         uint256 depositAmount = uint104(amount);
         // If we have a pending deposit in the current round, we add on to the pending deposit

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -348,7 +348,7 @@ contract RibbonVault is
                 roundPricePerShare[depositReceipt.round],
                 vaultParams.decimals
             );
-        
+
         uint256 depositAmount = amount;
 
         uint256 depositAmount = uint104(amount);

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -517,9 +517,9 @@ contract RibbonVault is
     function initRounds(uint256 numRounds) external nonReentrant {
         require(numRounds > 0, "!numRounds");
 
-        uint16 _round = vaultState.round;
-        for (uint16 i = 0; i < numRounds; i++) {
-            uint16 index = _round + i;
+        uint256 _round = vaultState.round;
+        for (uint256 i = 0; i < numRounds; i++) {
+            uint256 index = _round + i;
             require(index >= _round, "Overflow");
             require(roundPricePerShare[index] == 0, "Initialized"); // AVOID OVERWRITING ACTUAL VALUES
             roundPricePerShare[index] = ShareMath.PLACEHOLDER_UINT;
@@ -555,14 +555,14 @@ contract RibbonVault is
         optionState.nextOption = address(0);
 
         // Finalize the pricePerShare at the end of the round
-        uint16 currentRound = vaultState.round;
+        uint256 currentRound = vaultState.round;
         roundPricePerShare[currentRound] = newPricePerShare;
 
         // Take management / performance fee from previous round and deduct
         lockedBalance = _lockedBalance.sub(_collectVaultFees(_lockedBalance));
 
         vaultState.totalPending = 0;
-        vaultState.round = currentRound + 1;
+        vaultState.round = uint16(currentRound + 1);
 
         _mint(address(this), mintShares);
 

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -342,7 +342,7 @@ contract RibbonVault is
         Vault.DepositReceipt memory depositReceipt = depositReceipts[creditor];
 
         // If we have an unprocessed pending deposit from the previous rounds, we have to process it.
-        uint128 unredeemedShares =
+        uint256 unredeemedShares =
             depositReceipt.getSharesFromReceipt(
                 currentRound,
                 roundPricePerShare[depositReceipt.round],
@@ -351,7 +351,6 @@ contract RibbonVault is
 
         uint256 depositAmount = amount;
 
-        uint256 depositAmount = uint104(amount);
         // If we have a pending deposit in the current round, we add on to the pending deposit
         if (currentRound == depositReceipt.round) {
             uint256 newAmount = uint256(depositReceipt.amount).add(amount);
@@ -364,7 +363,7 @@ contract RibbonVault is
             processed: false,
             round: uint16(currentRound),
             amount: uint104(depositAmount),
-            unredeemedShares: unredeemedShares
+            unredeemedShares: uint128(unredeemedShares)
         });
 
         uint256 newTotalPending = uint256(vaultState.totalPending).add(amount);
@@ -473,7 +472,7 @@ contract RibbonVault is
      * @param isMax is flag for when callers do a max redemption
      */
     function _redeem(uint256 shares, bool isMax) internal {
-        ShareMath.assertUint104(shares);
+        ShareMath.assertUint128(shares);
 
         Vault.DepositReceipt memory depositReceipt =
             depositReceipts[msg.sender];
@@ -483,7 +482,7 @@ contract RibbonVault is
         uint16 currentRound = vaultState.round;
         require(depositReceipt.round < currentRound, "Round not closed");
 
-        uint128 unredeemedShares =
+        uint256 unredeemedShares =
             depositReceipt.getSharesFromReceipt(
                 currentRound,
                 roundPricePerShare[depositReceipt.round],
@@ -498,7 +497,7 @@ contract RibbonVault is
         depositReceipts[msg.sender].amount = 0;
         depositReceipts[msg.sender].processed = true;
         depositReceipts[msg.sender].unredeemedShares = uint128(
-            uint256(unredeemedShares).sub(shares)
+            unredeemedShares.sub(shares)
         );
 
         emit Redeem(msg.sender, shares, depositReceipt.round);
@@ -688,7 +687,7 @@ contract RibbonVault is
             return (balanceOf(account), 0);
         }
 
-        uint128 unredeemedShares =
+        uint256 unredeemedShares =
             depositReceipt.getSharesFromReceipt(
                 vaultState.round,
                 roundPricePerShare[depositReceipt.round],

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -87,7 +87,6 @@ contract RibbonVault is
     /// @notice 7 day period between each options sale.
     uint256 public constant PERIOD = 7 days;
 
-
     // Number of weeks per year = 52.142857 weeks * FEE_DECIMALS = 52142857
     // Dividing by weeks per year requires doing num.mul(FEE_DECIMALS).div(WEEKS_PER_YEAR)
     uint256 private constant WEEKS_PER_YEAR = 52142857;
@@ -583,6 +582,7 @@ contract RibbonVault is
             currentLockedBalance.sub(vaultState.totalPending);
 
         uint256 vaultFee;
+        uint256 performanceFeeInAsset;
 
         // Take performance fee and management fee ONLY if difference between
         // last week and this week's vault deposits, taking into account pending
@@ -590,13 +590,12 @@ contract RibbonVault is
         // option expired ITM past breakeven, and the vault took a loss so we
         // do not collect performance fee for last week
         if (lockedBalanceSansPending > prevLockedAmount) {
-            uint256 performanceFeeInAsset =
-                performanceFee > 0
-                    ? lockedBalanceSansPending
-                        .sub(prevLockedAmount)
-                        .mul(performanceFee)
-                        .div(100 * Vault.FEE_DECIMALS)
-                    : 0;
+            performanceFeeInAsset = performanceFee > 0
+                ? lockedBalanceSansPending
+                    .sub(prevLockedAmount)
+                    .mul(performanceFee)
+                    .div(100 * Vault.FEE_DECIMALS)
+                : 0;
             uint256 managementFeeInAsset =
                 managementFee > 0
                     ? currentLockedBalance.mul(managementFee).div(

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -39,7 +39,7 @@ contract RibbonVault is
     /// @notice On every round's close, the pricePerShare value of an rTHETA token is stored
     /// This is used to determine the number of shares to be returned
     /// to a user with their DepositReceipt.depositAmount
-    mapping(uint16 => uint256) public roundPricePerShare;
+    mapping(uint256 => uint256) public roundPricePerShare;
 
     /// @notice Stores pending user withdrawals
     mapping(address => Vault.Withdrawal) public withdrawals;
@@ -117,7 +117,7 @@ contract RibbonVault is
         uint256 round
     );
 
-    event Redeem(address indexed account, uint256 share, uint16 round);
+    event Redeem(address indexed account, uint256 share, uint256 round);
 
     event ManagementFeeSet(uint256 managementFee, uint256 newManagementFee);
 
@@ -399,15 +399,15 @@ contract RibbonVault is
 
         uint256 withdrawalShares;
         if (topup) {
-            withdrawalShares = existingShares.add(shares);
+            withdrawalShares = existingShares.add(numShares);
         } else {
             require(existingShares == 0, "Existing withdraw");
-            withdrawalShares = shares;
+            withdrawalShares = numShares;
             withdrawals[msg.sender].round = uint16(currentRound);
         }
 
         uint256 newQueuedWithdrawShares =
-            uint256(vaultState.queuedWithdrawShares).add(shares);
+            uint256(vaultState.queuedWithdrawShares).add(numShares);
         ShareMath.assertUint128(newQueuedWithdrawShares);
         vaultState.queuedWithdrawShares = uint128(newQueuedWithdrawShares);
 
@@ -437,7 +437,7 @@ contract RibbonVault is
         uint256 withdrawAmount =
             ShareMath.sharesToUnderlying(
                 withdrawalShares,
-                roundPricePerShare[uint16(withdrawalRound)],
+                roundPricePerShare[withdrawalRound],
                 vaultParams.decimals
             );
 
@@ -476,7 +476,7 @@ contract RibbonVault is
 
         // This handles the null case when depositReceipt.round = 0
         // Because we start with round = 1 at `initialize`
-        uint16 currentRound = vaultState.round;
+        uint256 currentRound = vaultState.round;
         require(depositReceipt.round < currentRound, "Round not closed");
 
         uint256 unredeemedShares =

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -376,7 +376,7 @@ contract RibbonVault is
      * @notice Initiates a withdrawal that can be processed once the round completes
      * @param shares is the number of shares to withdraw
      */
-    function initiateWithdraw(uint128 shares) external nonReentrant {
+    function initiateWithdraw(uint256 shares) external nonReentrant {
         require(shares > 0, "!shares");
 
         // We do a max redeem before initiating a withdrawal
@@ -472,8 +472,6 @@ contract RibbonVault is
      * @param isMax is flag for when callers do a max redemption
      */
     function _redeem(uint256 shares, bool isMax) internal {
-        ShareMath.assertUint128(shares);
-
         Vault.DepositReceipt memory depositReceipt =
             depositReceipts[msg.sender];
 
@@ -496,6 +494,7 @@ contract RibbonVault is
         // This zeroes out any pending amount from depositReceipt
         depositReceipts[msg.sender].amount = 0;
         depositReceipts[msg.sender].processed = true;
+        ShareMath.assertUint128(shares);
         depositReceipts[msg.sender].unredeemedShares = uint128(
             unredeemedShares.sub(shares)
         );
@@ -651,7 +650,7 @@ contract RibbonVault is
         view
         returns (uint256)
     {
-        uint8 decimals = vaultParams.decimals;
+        uint256 decimals = vaultParams.decimals;
         uint256 numShares = shares(account);
         uint256 pps =
             totalBalance().sub(vaultState.totalPending).mul(10**decimals).div(

--- a/test/RibbonDeltaVault.ts
+++ b/test/RibbonDeltaVault.ts
@@ -863,7 +863,6 @@ function behavesLikeRibbonOptionsVault(params: {
             feeRecipient,
             managementFee,
             performanceFee,
-            "0",
             tokenName,
             tokenSymbol,
             thetaVault.address,

--- a/test/RibbonDeltaVault.ts
+++ b/test/RibbonDeltaVault.ts
@@ -1950,7 +1950,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await vault.maxRedeem();
 
-        await expect(vault.maxRedeem()).to.be.revertedWith("!shares");
+        await expect(vault.maxRedeem()).to.be.revertedWith("!numShares");
       });
 
       it("reverts when redeeming after implicit redemption", async function () {
@@ -2098,7 +2098,7 @@ function behavesLikeRibbonOptionsVault(params: {
           .approve(vault.address, depositAmount);
         await vault.deposit(depositAmount);
         await rollToNextOption();
-        await expect(vault.redeem(0)).to.be.revertedWith("!shares");
+        await expect(vault.redeem(0)).to.be.revertedWith("!numShares");
       });
 
       it("reverts when redeeming more than available", async function () {
@@ -2176,7 +2176,9 @@ function behavesLikeRibbonOptionsVault(params: {
       });
 
       it("reverts when passed 0 shares", async function () {
-        await expect(vault.withdrawInstantly(0)).to.be.revertedWith("!shares");
+        await expect(vault.withdrawInstantly(0)).to.be.revertedWith(
+          "!numShares"
+        );
       });
 
       it("reverts when no deposit made", async function () {
@@ -2320,7 +2322,9 @@ function behavesLikeRibbonOptionsVault(params: {
       });
 
       it("reverts when passed 0 shares", async function () {
-        await expect(vault.initiateWithdraw(0)).to.be.revertedWith("!shares");
+        await expect(vault.initiateWithdraw(0)).to.be.revertedWith(
+          "!numShares"
+        );
       });
 
       it("reverts when withdrawing more than unredeemed balance", async function () {

--- a/test/RibbonDeltaVault.ts
+++ b/test/RibbonDeltaVault.ts
@@ -2101,20 +2101,6 @@ function behavesLikeRibbonOptionsVault(params: {
         await expect(vault.redeem(0)).to.be.revertedWith("!shares");
       });
 
-      it("overflows when shares >uint104", async function () {
-        const redeemAmount = BigNumber.from(
-          "340282366920938463463374607431768211455"
-        );
-        await assetContract
-          .connect(userSigner)
-          .approve(vault.address, depositAmount);
-        await vault.deposit(depositAmount);
-        await rollToNextOption();
-        await expect(vault.redeem(redeemAmount)).to.be.revertedWith(
-          "Overflow uint104"
-        );
-      });
-
       it("reverts when redeeming more than available", async function () {
         await assetContract
           .connect(userSigner)

--- a/test/RibbonDeltaVault.ts
+++ b/test/RibbonDeltaVault.ts
@@ -707,7 +707,7 @@ function behavesLikeRibbonOptionsVault(params: {
         assert.equal(await vault.counterpartyThetaVault(), thetaVault.address);
         assert.bnEqual(cap, parseEther("500"));
         assert.equal(
-          (await vault.optionAllocation()).toString(),
+          (await vault.optionAllocationPct()).toString(),
           optionAllocationPct.toString()
         );
       });
@@ -862,6 +862,7 @@ function behavesLikeRibbonOptionsVault(params: {
             owner,
             feeRecipient,
             managementFee,
+            performanceFee,
             "0",
             tokenName,
             tokenSymbol,
@@ -1358,7 +1359,7 @@ function behavesLikeRibbonOptionsVault(params: {
         await time.increaseTo((await getNextOptionReadyAt()) + 1);
 
         let bidAmount = (await lockedBalanceForRollover(assetContract, vault))
-          .mul(await vault.optionAllocation())
+          .mul(await vault.optionAllocationPct())
           .div(BigNumber.from(10000));
 
         let numOTokens = bidAmount
@@ -1430,7 +1431,7 @@ function behavesLikeRibbonOptionsVault(params: {
         await time.increaseTo((await getNextOptionReadyAt()) + 1);
 
         let bidAmount = (await lockedBalanceForRollover(assetContract, vault))
-          .mul(await vault.optionAllocation())
+          .mul(await vault.optionAllocationPct())
           .div(BigNumber.from(10000));
 
         let numOTokens = bidAmount
@@ -1477,7 +1478,7 @@ function behavesLikeRibbonOptionsVault(params: {
         await time.increaseTo((await getNextOptionReadyAt()) + 1);
 
         let bidAmount = (await lockedBalanceForRollover(assetContract, vault))
-          .mul(await vault.optionAllocation())
+          .mul(await vault.optionAllocationPct())
           .div(BigNumber.from(10000));
 
         let numOTokens = bidAmount
@@ -1597,7 +1598,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         let newBidAmount = secondInitialLockedBalance
           .sub(vaultFees)
-          .mul(await vault.optionAllocation())
+          .mul(await vault.optionAllocationPct())
           .div(BigNumber.from(10000));
 
         let newNumOTokens = newBidAmount
@@ -1638,7 +1639,7 @@ function behavesLikeRibbonOptionsVault(params: {
         await time.increaseTo((await getNextOptionReadyAt()) + 1);
 
         let bidAmount = (await lockedBalanceForRollover(assetContract, vault))
-          .mul(await vault.optionAllocation())
+          .mul(await vault.optionAllocationPct())
           .div(BigNumber.from(10000));
 
         let numOTokens = bidAmount
@@ -1740,7 +1741,7 @@ function behavesLikeRibbonOptionsVault(params: {
         let newBidAmount = (
           await lockedBalanceForRollover(assetContract, vault)
         )
-          .mul(await vault.optionAllocation())
+          .mul(await vault.optionAllocationPct())
           .div(BigNumber.from(10000));
 
         let newNumOTokens = newBidAmount
@@ -2613,7 +2614,7 @@ function behavesLikeRibbonOptionsVault(params: {
           .connect(ownerSigner)
           .setOptionAllocation(BigNumber.from("100"));
         assert.bnEqual(
-          BigNumber.from(await vault.optionAllocation()),
+          BigNumber.from(await vault.optionAllocationPct()),
           BigNumber.from("100")
         );
       });

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1265,7 +1265,7 @@ function behavesLikeRibbonOptionsVault(params: {
           .commitAndClose({ from: owner });
 
         const receipt = await res.wait();
-        assert.isAtMost(receipt.gasUsed.toNumber(), 1045000);
+        assert.isAtMost(receipt.gasUsed.toNumber(), 1050000);
         // console.log("commitAndClose", receipt.gasUsed.toNumber());
       });
     });
@@ -2094,20 +2094,6 @@ function behavesLikeRibbonOptionsVault(params: {
         await vault.deposit(depositAmount);
         await rollToNextOption();
         await expect(vault.redeem(0)).to.be.revertedWith("!shares");
-      });
-
-      it("overflows when shares >uint104", async function () {
-        const redeemAmount = BigNumber.from(
-          "340282366920938463463374607431768211455"
-        );
-        await assetContract
-          .connect(userSigner)
-          .approve(vault.address, depositAmount);
-        await vault.deposit(depositAmount);
-        await rollToNextOption();
-        await expect(vault.redeem(redeemAmount)).to.be.revertedWith(
-          "Overflow uint104"
-        );
       });
 
       it("reverts when redeeming more than available", async function () {

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1966,7 +1966,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await vault.maxRedeem();
 
-        await expect(vault.maxRedeem()).to.be.revertedWith("!shares");
+        await expect(vault.maxRedeem()).to.be.revertedWith("!numShares");
       });
 
       it("reverts when redeeming after implicit redemption", async function () {
@@ -2093,7 +2093,7 @@ function behavesLikeRibbonOptionsVault(params: {
           .approve(vault.address, depositAmount);
         await vault.deposit(depositAmount);
         await rollToNextOption();
-        await expect(vault.redeem(0)).to.be.revertedWith("!shares");
+        await expect(vault.redeem(0)).to.be.revertedWith("!numShares");
       });
 
       it("reverts when redeeming more than available", async function () {
@@ -2266,7 +2266,9 @@ function behavesLikeRibbonOptionsVault(params: {
       });
 
       it("reverts when passed 0 shares", async function () {
-        await expect(vault.initiateWithdraw(0)).to.be.revertedWith("!shares");
+        await expect(vault.initiateWithdraw(0)).to.be.revertedWith(
+          "!numShares"
+        );
       });
 
       it("reverts when withdrawing more than unredeemed balance", async function () {


### PR DESCRIPTION
Comment:

>vaultState.round is unnecessarily cast to a uint256, only for it to be cast back to a uint16 without modifying it. This happens again in the initiateWithdraw function and the completeWithdraw function. (https://github.com/ribbon-finance/ribbon-v2/blob/3fa3bec15ad1e2b18ad87f979b87a68368497f13/contracts/vaults/base/RibbonVault.sol#L293)

We're using uint256 for the `currentRound` variable because it's more efficient, casting it back to uint16 to store is cheap.
