### PR TITLE
[L10] Naming issues hinder code understanding and readability

### DIFF
--- a/contracts/interfaces/IRibbon.sol
+++ b/contracts/interfaces/IRibbon.sol
@@ -18,10 +18,10 @@ interface IOptionsPremiumPricer {
     ) external view returns (uint256);
 
     function getOptionDelta(
-        uint256 sp,
-        uint256 st,
-        uint256 v,
-        uint256 t
+        uint256 spotPrice,
+        uint256 strikePrice,
+        uint256 volatility,
+        uint256 expiryTimestamp
     ) external view returns (uint256 delta);
 
     function getUnderlyingPrice() external view returns (uint256 price);

--- a/contracts/libraries/GnosisAuction.sol
+++ b/contracts/libraries/GnosisAuction.sol
@@ -18,7 +18,7 @@ library GnosisAuction {
     event InitiateGnosisAuction(
         address auctioningToken,
         address biddingToken,
-        uint256 auctionCounter,
+        uint256 auctionID,
         address manager
     );
 

--- a/contracts/libraries/GnosisAuction.sol
+++ b/contracts/libraries/GnosisAuction.sol
@@ -79,7 +79,7 @@ library GnosisAuction {
             .initiateAuction(
             // address of oToken we minted and are selling
             auctionDetails.oTokenAddress,
-            // address of asset we want in exchange for oTokens. Should match vault collateral
+            // address of asset we want in exchange for oTokens. Should match vault `asset`
             auctionDetails.asset,
             // orders can be cancelled before the auction's halfway point
             block.timestamp.add(auctionDetails.duration.div(2)),

--- a/contracts/libraries/ShareMath.sol
+++ b/contracts/libraries/ShareMath.sol
@@ -10,8 +10,8 @@ library ShareMath {
 
     uint256 constant PLACEHOLDER_UINT = 1;
 
-    function underlyingToShares(
-        uint256 underlyingAmount,
+    function assetToShares(
+        uint256 assetAmount,
         uint256 pps,
         uint8 decimals
     ) internal pure returns (uint104) {
@@ -21,13 +21,13 @@ library ShareMath {
         require(pps > PLACEHOLDER_UINT, "Invalid pps");
 
         uint256 shares =
-            uint256(underlyingAmount).mul(10**uint256(decimals)).div(pps);
+            uint256(assetAmount).mul(10**uint256(decimals)).div(pps);
         assertUint104(shares);
 
         return uint104(shares);
     }
 
-    function sharesToUnderlying(
+    function sharesToAsset(
         uint256 shares,
         uint256 pps,
         uint8 decimals
@@ -37,19 +37,19 @@ library ShareMath {
         // Has to be larger than 1 because `1` is used in `initRoundPricePerShares` to prevent cold writes.
         require(pps > PLACEHOLDER_UINT, "Invalid pps");
 
-        uint256 underlyingAmount =
+        uint256 assetAmount =
             uint256(shares).mul(pps).div(10**uint256(decimals));
         assertUint104(shares);
 
-        return underlyingAmount;
+        return assetAmount;
     }
 
     /**
      * @notice Returns the shares unredeemed by the user given their DepositReceipt
      * @param depositReceipt is the user's deposit receipt
      * @param currentRound is the `round` stored on the vault
-     * @param pps is the price in underlying per share
-     * @param decimals is the number of decimals the underlying/shares use
+     * @param pps is the price in asset per share
+     * @param decimals is the number of decimals the asset/shares use
      * @return unredeemedShares is the user's virtual balance of shares that are owed
      */
     function getSharesFromReceipt(
@@ -64,7 +64,7 @@ library ShareMath {
             !depositReceipt.processed
         ) {
             uint256 sharesFromRound =
-                underlyingToShares(depositReceipt.amount, pps, decimals);
+                assetToShares(depositReceipt.amount, pps, decimals);
 
             assertUint104(sharesFromRound);
 

--- a/contracts/libraries/ShareMath.sol
+++ b/contracts/libraries/ShareMath.sol
@@ -12,16 +12,16 @@ library ShareMath {
 
     function assetToShares(
         uint256 assetAmount,
-        uint256 pps,
+        uint256 assetPerShare,
         uint8 decimals
     ) internal pure returns (uint104) {
         // If this throws, it means that vault's roundPricePerShare[currentRound] has not been set yet
         // which should never happen.
         // Has to be larger than 1 because `1` is used in `initRoundPricePerShares` to prevent cold writes.
-        require(pps > PLACEHOLDER_UINT, "Invalid pps");
+        require(assetPerShare > PLACEHOLDER_UINT, "Invalid assetPerShare");
 
         uint256 shares =
-            uint256(assetAmount).mul(10**uint256(decimals)).div(pps);
+            uint256(assetAmount).mul(10**uint256(decimals)).div(assetPerShare);
         assertUint104(shares);
 
         return uint104(shares);
@@ -29,16 +29,16 @@ library ShareMath {
 
     function sharesToAsset(
         uint256 shares,
-        uint256 pps,
+        uint256 assetPerShare,
         uint8 decimals
     ) internal pure returns (uint256) {
         // If this throws, it means that vault's roundPricePerShare[currentRound] has not been set yet
         // which should never happen.
         // Has to be larger than 1 because `1` is used in `initRoundPricePerShares` to prevent cold writes.
-        require(pps > PLACEHOLDER_UINT, "Invalid pps");
+        require(assetPerShare > PLACEHOLDER_UINT, "Invalid assetPerShare");
 
         uint256 assetAmount =
-            uint256(shares).mul(pps).div(10**uint256(decimals));
+            uint256(shares).mul(assetPerShare).div(10**uint256(decimals));
         assertUint104(shares);
 
         return assetAmount;
@@ -48,14 +48,14 @@ library ShareMath {
      * @notice Returns the shares unredeemed by the user given their DepositReceipt
      * @param depositReceipt is the user's deposit receipt
      * @param currentRound is the `round` stored on the vault
-     * @param pps is the price in asset per share
+     * @param assetPerShare is the price in asset per share
      * @param decimals is the number of decimals the asset/shares use
      * @return unredeemedShares is the user's virtual balance of shares that are owed
      */
     function getSharesFromReceipt(
         Vault.DepositReceipt memory depositReceipt,
         uint256 currentRound,
-        uint256 pps,
+        uint256 assetPerShare,
         uint8 decimals
     ) internal pure returns (uint128 unredeemedShares) {
         if (
@@ -64,7 +64,7 @@ library ShareMath {
             !depositReceipt.processed
         ) {
             uint256 sharesFromRound =
-                assetToShares(depositReceipt.amount, pps, decimals);
+                assetToShares(depositReceipt.amount, assetPerShare, decimals);
 
             assertUint104(sharesFromRound);
 

--- a/contracts/libraries/SupportsNonCompliantERC20.sol
+++ b/contracts/libraries/SupportsNonCompliantERC20.sol
@@ -3,10 +3,15 @@ pragma solidity ^0.7.3;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
+/**
+ * This library supports ERC20s that have quirks in their behavior.
+ * One such ERC20 is USDT, which requires allowance to be 0 before calling approve.
+ * We plan to update this library with ERC20s that display such idiosyncratic behavior.
+ */
 library SupportsNonCompliantERC20 {
     address constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
 
-    function safeApprove(
+    function safeApproveNonCompliant(
         IERC20 token,
         address spender,
         uint256 amount

--- a/contracts/libraries/Vault.sol
+++ b/contracts/libraries/Vault.sol
@@ -38,7 +38,7 @@ library Vault {
         // used for calculating performance fee deduction
         uint104 lastLockedAmount;
         // 32 byte slot 2
-        // Stores the total tally of how much of collateral there is
+        // Stores the total tally of how much of `asset` there is
         // to be used to mint rTHETA tokens
         uint128 totalPending;
         // Amount locked for scheduled withdrawals;

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -31,7 +31,7 @@ library VaultLifecycle {
         address USDC;
         address currentOption;
         uint256 delay;
-        uint16 lastStrikeOverride;
+        uint16 lastStrikeOverrideRound;
         uint256 overriddenStrikePrice;
     }
 
@@ -68,7 +68,7 @@ library VaultLifecycle {
         address underlying = vaultParams.underlying;
         address asset = vaultParams.asset;
 
-        (strikePrice, delta) = closeParams.lastStrikeOverride ==
+        (strikePrice, delta) = closeParams.lastStrikeOverrideRound ==
             vaultState.round
             ? (closeParams.overriddenStrikePrice, selection.delta())
             : selection.getStrikePrice(expiry, isPut);

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -164,6 +164,8 @@ library VaultLifecycle {
         uint256 newVaultID =
             (controller.getAccountVaultCounter(address(this))).add(1);
 
+        // An otoken's collateralAsset is the vault's `asset`
+        // So in the context of performing Opyn short operations we call them collateralAsset
         IOtoken oToken = IOtoken(oTokenAddress);
         address collateralAsset = oToken.collateralAsset();
 
@@ -263,8 +265,11 @@ library VaultLifecycle {
 
         require(vault.shortOtokens.length > 0, "No short");
 
+        // An otoken's collateralAsset is the vault's `asset`
+        // So in the context of performing Opyn short operations we call them collateralAsset
         IERC20 collateralToken = IERC20(vault.collateralAssets[0]);
 
+        // This is equivalent to doing IERC20(vault.asset).balanceOf(address(this))
         uint256 startCollateralBalance =
             collateralToken.balanceOf(address(this));
 

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -102,7 +102,7 @@ library VaultLifecycle {
     }
 
     function rollover(
-        uint256 currentSupply,
+        uint256 currentShareSupply,
         address asset,
         uint8 decimals,
         uint256 initialSharePrice,
@@ -123,7 +123,7 @@ library VaultLifecycle {
         uint256 singleShare = 10**uint256(decimals);
 
         newPricePerShare = getPPS(
-            currentSupply,
+            currentShareSupply,
             roundStartBalance,
             singleShare,
             initialSharePrice
@@ -135,7 +135,7 @@ library VaultLifecycle {
         uint256 _mintShares =
             pendingAmount.mul(singleShare).div(newPricePerShare);
 
-        uint256 newSupply = currentSupply.add(_mintShares);
+        uint256 newSupply = currentShareSupply.add(_mintShares);
 
         uint256 queuedWithdrawAmount =
             newSupply > 0
@@ -152,7 +152,7 @@ library VaultLifecycle {
     }
 
     // https://github.com/opynfinance/GammaProtocol/blob/master/contracts/Otoken.sol#L70
-    uint256 private constant OTOKEN_DECIMALS = 10**8;
+    uint256 private constant OTOKEN_MULTIPLIER = 10**8;
 
     function createShort(
         address gammaController,
@@ -189,7 +189,7 @@ library VaultLifecycle {
             // MarginCalculatorInterface(0x7A48d10f372b3D7c60f6c9770B91398e4ccfd3C7).getExcessCollateral(vault)
             // to see how much dust (or excess collateral) is left behind.
             mintAmount = depositAmount
-                .mul(OTOKEN_DECIMALS)
+                .mul(OTOKEN_MULTIPLIER)
                 .mul(DSWAD) // we use 10**18 to give extra precision
                 .div(
                 oToken.strikePrice().mul(10**(18 - (8 - collateralDecimals)))
@@ -205,7 +205,7 @@ library VaultLifecycle {
 
         // double approve to fix non-compliant ERC20s
         IERC20 collateralToken = IERC20(collateralAsset);
-        collateralToken.safeApprove(marginPool, depositAmount);
+        collateralToken.safeApproveNonCompliant(marginPool, depositAmount);
 
         IController.ActionArgs[] memory actions =
             new IController.ActionArgs[](3);
@@ -464,7 +464,7 @@ library VaultLifecycle {
         );
     }
 
-    function verifyConstructorParams(
+    function verifyInitializerParams(
         address owner,
         address feeRecipient,
         uint256 performanceFee,

--- a/contracts/storage/RibbonThetaVaultStorage.sol
+++ b/contracts/storage/RibbonThetaVaultStorage.sol
@@ -11,7 +11,7 @@ abstract contract RibbonThetaVaultStorageV1 {
     // Current oToken premium
     uint104 public currentOtokenPremium;
     // Last round id at which the strike was manually overridden
-    uint16 public lastStrikeOverride;
+    uint16 public lastStrikeOverrideRound;
     // Price last overridden strike set to
     uint128 public overriddenStrikePrice;
     // Auction duration

--- a/contracts/vaults/RibbonDeltaVault.sol
+++ b/contracts/vaults/RibbonDeltaVault.sol
@@ -36,14 +36,14 @@ contract RibbonDeltaVault is RibbonVault, DSMath, RibbonDeltaVaultStorage {
      ***********************************************/
 
     event OpenLong(
-        address indexed options,
+        address indexed option,
         uint256 purchaseAmount,
         uint256 premium,
         address manager
     );
 
     event CloseLong(
-        address indexed options,
+        address indexed option,
         uint256 profitAmount,
         address manager
     );

--- a/contracts/vaults/RibbonDeltaVault.sol
+++ b/contracts/vaults/RibbonDeltaVault.sol
@@ -229,13 +229,13 @@ contract RibbonDeltaVault is RibbonVault, DSMath, RibbonDeltaVaultStorage {
 
         emit InstantWithdraw(msg.sender, share, currentRound);
 
-        uint256 sharesToUnderlying =
-            ShareMath.sharesToUnderlying(
+        uint256 withdrawAmount =
+            ShareMath.sharesToAsset(
                 share,
                 roundPricePerShare[vaultState.round],
                 vaultParams.decimals
             );
-        transferAsset(msg.sender, sharesToUnderlying);
+        transferAsset(msg.sender, withdrawAmount);
     }
 
     /************************************************
@@ -334,7 +334,7 @@ contract RibbonDeltaVault is RibbonVault, DSMath, RibbonDeltaVaultStorage {
             depositReceipt.amount > 0
         ) {
             uint256 receiptShares =
-                ShareMath.underlyingToShares(
+                ShareMath.assetToShares(
                     depositReceipt.amount,
                     roundPricePerShare[depositReceipt.round],
                     vaultParams.decimals
@@ -342,7 +342,7 @@ contract RibbonDeltaVault is RibbonVault, DSMath, RibbonDeltaVaultStorage {
             uint256 sharesWithdrawn = min(receiptShares, share);
             // Subtraction underflow checks already ensure it is smaller than uint104
             depositReceipt.amount = uint104(
-                ShareMath.sharesToUnderlying(
+                ShareMath.sharesToAsset(
                     uint256(receiptShares).sub(sharesWithdrawn),
                     roundPricePerShare[depositReceipt.round],
                     vaultParams.decimals

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -68,7 +68,7 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
     event InitiateGnosisAuction(
         address auctioningToken,
         address biddingToken,
-        uint256 auctionCounter,
+        uint256 auctionID,
         address manager
     );
 
@@ -313,10 +313,10 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
         uint256 numOTokensToBurn =
             IERC20(optionState.currentOption).balanceOf(address(this));
         require(numOTokensToBurn > 0, "!otokens");
-        uint256 unlockedAssedAmount =
+        uint256 unlockedAssetAmount =
             VaultLifecycle.burnOtokens(GAMMA_CONTROLLER, numOTokensToBurn);
         vaultState.lockedAmount = uint104(
-            uint256(vaultState.lockedAmount).sub(unlockedAssedAmount)
+            uint256(vaultState.lockedAmount).sub(unlockedAssetAmount)
         );
     }
 

--- a/contracts/vaults/RibbonThetaVault.sol
+++ b/contracts/vaults/RibbonThetaVault.sol
@@ -217,7 +217,7 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
                 USDC: USDC,
                 currentOption: oldOption,
                 delay: delay,
-                lastStrikeOverride: lastStrikeOverride,
+                lastStrikeOverrideRound: lastStrikeOverrideRound,
                 overriddenStrikePrice: overriddenStrikePrice
             });
 
@@ -331,6 +331,6 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
     {
         require(strikePrice > 0, "!strikePrice");
         overriddenStrikePrice = strikePrice;
-        lastStrikeOverride = vaultState.round;
+        lastStrikeOverrideRound = vaultState.round;
     }
 }

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -421,7 +421,7 @@ contract RibbonVault is
         );
 
         uint256 withdrawAmount =
-            ShareMath.sharesToUnderlying(
+            ShareMath.sharesToAsset(
                 withdrawalShares,
                 roundPricePerShare[uint16(withdrawalRound)],
                 vaultParams.decimals
@@ -613,7 +613,7 @@ contract RibbonVault is
      ***********************************************/
 
     /**
-     * @notice Returns the underlying balance held on the vault for the account
+     * @notice Returns the asset balance held on the vault for the account
      * @param account is the address to lookup balance for
      */
     function accountVaultBalance(address account)
@@ -627,7 +627,7 @@ contract RibbonVault is
             totalBalance().sub(vaultState.totalPending).mul(10**decimals).div(
                 totalSupply()
             );
-        return ShareMath.sharesToUnderlying(numShares, pps, decimals);
+        return ShareMath.sharesToAsset(numShares, pps, decimals);
     }
 
     /**
@@ -668,7 +668,7 @@ contract RibbonVault is
     }
 
     /**
-     * @notice The price of a unit of share denominated in the `collateral`
+     * @notice The price of a unit of share denominated in the `asset`
      */
     function pricePerShare() external view returns (uint256) {
         uint256 balance = totalBalance().sub(vaultState.totalPending);

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -177,7 +177,7 @@ contract RibbonVault is
         string memory tokenSymbol,
         Vault.VaultParams calldata _vaultParams
     ) internal initializer {
-        VaultLifecycle.verifyConstructorParams(
+        VaultLifecycle.verifyInitializerParams(
             _owner,
             _feeRecipient,
             _performanceFee,
@@ -374,13 +374,13 @@ contract RibbonVault is
         uint256 currentRound = vaultState.round;
         Vault.Withdrawal storage withdrawal = withdrawals[msg.sender];
 
-        bool topup = withdrawal.round == currentRound;
+        bool withdrawalIsSameRound = withdrawal.round == currentRound;
 
         emit InitiateWithdraw(msg.sender, shares, currentRound);
 
         uint256 withdrawalShares = uint256(withdrawal.shares);
 
-        if (topup) {
+        if (withdrawalIsSameRound) {
             uint256 increasedShares = withdrawalShares.add(shares);
             ShareMath.assertUint128(increasedShares);
             withdrawals[msg.sender].shares = uint128(increasedShares);

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1248,7 +1248,7 @@ function behavesLikeRibbonOptionsVault(params: {
             : BigNumber.from("4050000000000");
         await vault.connect(ownerSigner).setStrikePrice(newStrikePrice);
 
-        assert.equal((await vault.lastStrikeOverride()).toString(), "1");
+        assert.equal((await vault.lastStrikeOverrideRound()).toString(), "1");
         assert.equal(
           (await vault.overriddenStrikePrice()).toString(),
           newStrikePrice.toString()


### PR DESCRIPTION
Rebased on top of oz-audit-h01 due to dependencies

WRT comments,

>• In the Vault contract, minimumSupply should be minimumInitialSupply.

This is not accurate, we enforce the share supply to be > `minimumSupply` all the time. The use of `initial` is not accurate