### PR TITLE
Refactor how queuedWithdrawAmount and mintShares is calculated

### DIFF
--- a/contracts/interfaces/IRibbonThetaVault.sol
+++ b/contracts/interfaces/IRibbonThetaVault.sol
@@ -16,8 +16,6 @@ library Vault {
         uint56 minimumSupply;
         // Vault cap
         uint104 cap;
-        // Round 1 asset/share price
-        uint256 initialSharePrice;
     }
 
     struct OptionState {

--- a/contracts/libraries/ShareMath.sol
+++ b/contracts/libraries/ShareMath.sol
@@ -78,6 +78,21 @@ library ShareMath {
         }
     }
 
+    function pricePerShare(
+        uint256 totalSupply,
+        uint256 totalBalance,
+        uint256 pendingAmount,
+        uint256 decimals
+    ) internal pure returns (uint256) {
+        uint256 singleShare = 10**decimals;
+        return
+            totalSupply > 0
+                ? singleShare.mul(totalBalance.sub(pendingAmount)).div(
+                    totalSupply
+                )
+                : singleShare;
+    }
+
     /************************************************
      *  HELPERS
      ***********************************************/

--- a/contracts/libraries/Vault.sol
+++ b/contracts/libraries/Vault.sol
@@ -15,8 +15,6 @@ library Vault {
         uint56 minimumSupply;
         // Vault cap
         uint104 cap;
-        // If migrating from existing vault, allows for smooth migration
-        uint256 initialSharePrice;
     }
 
     struct OptionState {

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -129,35 +129,35 @@ library VaultLifecycle {
         // After closing the short, if the options expire in-the-money
         // vault pricePerShare would go down because vault's asset balance decreased.
         // This ensures that the newly-minted shares do not take on the loss.
-        uint256 _mintShares =
-            ShareMath.underlyingToShares(
-                pendingAmount,
-                newPricePerShare,
-                decimals
-            );
-
-        uint256 newSupply = currentSupply.add(_mintShares);
-
-        uint256 queuedWithdrawAmount =
-            newSupply > 0
-                ? ShareMath.sharesToUnderlying(
-                    queuedWithdrawShares,
-                    newPricePerShare,
-                    decimals
-                )
-                : 0;
-
         // uint256 _mintShares =
-        //     pendingAmount.mul(10**decimals).div(newPricePerShare);
+        //     ShareMath.underlyingToShares(
+        //         pendingAmount,
+        //         newPricePerShare,
+        //         decimals
+        //     );
 
         // uint256 newSupply = currentSupply.add(_mintShares);
 
         // uint256 queuedWithdrawAmount =
         //     newSupply > 0
-        //         ? uint256(queuedWithdrawShares).mul(currentBalance).div(
-        //             newSupply
+        //         ? ShareMath.sharesToUnderlying(
+        //             queuedWithdrawShares,
+        //             newPricePerShare,
+        //             decimals
         //         )
         //         : 0;
+
+        uint256 _mintShares =
+            pendingAmount.mul(10**decimals).div(newPricePerShare);
+
+        uint256 newSupply = currentSupply.add(_mintShares);
+
+        uint256 queuedWithdrawAmount =
+            newSupply > 0
+                ? uint256(queuedWithdrawShares).mul(currentBalance).div(
+                    newSupply
+                )
+                : 0;
 
         return (
             currentBalance.sub(queuedWithdrawAmount),

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -130,14 +130,20 @@ library VaultLifecycle {
         // vault pricePerShare would go down because vault's asset balance decreased.
         // This ensures that the newly-minted shares do not take on the loss.
         uint256 _mintShares =
-            pendingAmount.mul(10**decimals).div(newPricePerShare);
+            ShareMath.underlyingToShares(
+                pendingAmount,
+                newPricePerShare,
+                decimals
+            );
 
         uint256 newSupply = currentSupply.add(_mintShares);
 
         uint256 queuedWithdrawAmount =
             newSupply > 0
-                ? uint256(queuedWithdrawShares).mul(currentBalance).div(
-                    newSupply
+                ? ShareMath.sharesToUnderlying(
+                    queuedWithdrawShares,
+                    newPricePerShare,
+                    decimals
                 )
                 : 0;
 

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -129,33 +129,21 @@ library VaultLifecycle {
         // After closing the short, if the options expire in-the-money
         // vault pricePerShare would go down because vault's asset balance decreased.
         // This ensures that the newly-minted shares do not take on the loss.
-        // uint256 _mintShares =
-        //     ShareMath.underlyingToShares(
-        //         pendingAmount,
-        //         newPricePerShare,
-        //         decimals
-        //     );
-
-        // uint256 newSupply = currentSupply.add(_mintShares);
-
-        // uint256 queuedWithdrawAmount =
-        //     newSupply > 0
-        //         ? ShareMath.sharesToUnderlying(
-        //             queuedWithdrawShares,
-        //             newPricePerShare,
-        //             decimals
-        //         )
-        //         : 0;
-
         uint256 _mintShares =
-            pendingAmount.mul(10**decimals).div(newPricePerShare);
+            ShareMath.underlyingToShares(
+                pendingAmount,
+                newPricePerShare,
+                decimals
+            );
 
         uint256 newSupply = currentSupply.add(_mintShares);
 
         uint256 queuedWithdrawAmount =
             newSupply > 0
-                ? uint256(queuedWithdrawShares).mul(currentBalance).div(
-                    newSupply
+                ? ShareMath.sharesToUnderlying(
+                    queuedWithdrawShares,
+                    newPricePerShare,
+                    decimals
                 )
                 : 0;
 

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -147,6 +147,18 @@ library VaultLifecycle {
                 )
                 : 0;
 
+        // uint256 _mintShares =
+        //     pendingAmount.mul(10**decimals).div(newPricePerShare);
+
+        // uint256 newSupply = currentSupply.add(_mintShares);
+
+        // uint256 queuedWithdrawAmount =
+        //     newSupply > 0
+        //         ? uint256(queuedWithdrawShares).mul(currentBalance).div(
+        //             newSupply
+        //         )
+        //         : 0;
+
         return (
             currentBalance.sub(queuedWithdrawAmount),
             newPricePerShare,

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -130,20 +130,14 @@ library VaultLifecycle {
         // vault pricePerShare would go down because vault's asset balance decreased.
         // This ensures that the newly-minted shares do not take on the loss.
         uint256 _mintShares =
-            ShareMath.underlyingToShares(
-                pendingAmount,
-                newPricePerShare,
-                decimals
-            );
+            pendingAmount.mul(10**decimals).div(newPricePerShare);
 
         uint256 newSupply = currentSupply.add(_mintShares);
 
         uint256 queuedWithdrawAmount =
             newSupply > 0
-                ? ShareMath.sharesToUnderlying(
-                    queuedWithdrawShares,
-                    newPricePerShare,
-                    decimals
+                ? uint256(queuedWithdrawShares).mul(currentBalance).div(
+                    newSupply
                 )
                 : 0;
 

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -106,7 +106,6 @@ library VaultLifecycle {
         uint256 currentSupply,
         address asset,
         uint8 decimals,
-        uint256,
         uint256 pendingAmount,
         uint128 queuedWithdrawShares
     )
@@ -482,7 +481,6 @@ library VaultLifecycle {
         require(_vaultParams.underlying != address(0), "!underlying");
         require(_vaultParams.minimumSupply > 0, "!minimumSupply");
         require(_vaultParams.cap > 0, "!cap");
-        require(_vaultParams.initialSharePrice > 0, "!initialSharePrice");
     }
 
     /**

--- a/contracts/tests/TestVaultLifecycle.sol
+++ b/contracts/tests/TestVaultLifecycle.sol
@@ -11,4 +11,35 @@ contract TestVaultLifecycle {
     {
         return VaultLifecycle.getNextFriday(currentExpiry);
     }
+
+    function balanceOf(address account) public view returns (uint256) {
+        if (account == address(this)) {
+            return 1 ether;
+        }
+    }
+
+    function rollover(
+        uint256 currentSupply,
+        address asset,
+        uint8 decimals,
+        uint256 pendingAmount,
+        uint128 queuedWithdrawShares
+    )
+        external
+        view
+        returns (
+            uint256 newLockedAmount,
+            uint256 newPricePerShare,
+            uint256 mintShares
+        )
+    {
+        return
+            VaultLifecycle.rollover(
+                currentSupply,
+                asset,
+                decimals,
+                pendingAmount,
+                queuedWithdrawShares
+            );
+    }
 }

--- a/contracts/vaults/RibbonDeltaVault.sol
+++ b/contracts/vaults/RibbonDeltaVault.sol
@@ -142,17 +142,11 @@ contract RibbonDeltaVault is RibbonVault, DSMath, OptionsDeltaVaultStorage {
             !isWithdraw ||
             roundPricePerShare[vaultState.round] <= PLACEHOLDER_UINT
         ) {
-            uint256 pendingAmount = uint256(vaultState.totalPending);
-            uint256 currentBalance =
-                IERC20(vaultParams.asset).balanceOf(address(this));
-            uint256 roundStartBalance = currentBalance.sub(pendingAmount);
-
-            uint256 singleShare = 10**uint256(vaultParams.decimals);
-            roundPricePerShare[vaultState.round] = VaultLifecycle.getPPS(
+            roundPricePerShare[vaultState.round] = ShareMath.pricePerShare(
                 totalSupply(),
-                roundStartBalance,
-                singleShare,
-                vaultParams.initialSharePrice
+                IERC20(vaultParams.asset).balanceOf(address(this)),
+                vaultState.totalPending,
+                vaultParams.decimals
             );
         }
 

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -567,13 +567,21 @@ contract RibbonVault is OptionsVaultStorage {
         view
         returns (uint256)
     {
-        uint8 decimals = vaultParams.decimals;
-        uint256 numShares = shares(account);
+        uint256 _decimals = vaultParams.decimals;
         uint256 pps =
-            totalBalance().sub(vaultState.totalPending).mul(10**decimals).div(
-                totalSupply()
+            ShareMath.pricePerShare(
+                totalSupply(),
+                totalBalance(),
+                vaultState.totalPending,
+                _decimals
             );
-        return ShareMath.sharesToUnderlying(numShares, pps, decimals);
+
+        return
+            ShareMath.sharesToUnderlying(
+                shares(account),
+                pps,
+                uint8(_decimals)
+            );
     }
 
     /**
@@ -617,9 +625,13 @@ contract RibbonVault is OptionsVaultStorage {
      * @notice The price of a unit of share denominated in the `collateral`
      */
     function pricePerShare() external view returns (uint256) {
-        uint256 balance = totalBalance().sub(vaultState.totalPending);
         return
-            (10**uint256(vaultParams.decimals)).mul(balance).div(totalSupply());
+            ShareMath.pricePerShare(
+                totalSupply(),
+                totalBalance(),
+                vaultState.totalPending,
+                vaultParams.decimals
+            );
     }
 
     /**

--- a/contracts/vaults/base/RibbonVault.sol
+++ b/contracts/vaults/base/RibbonVault.sol
@@ -475,7 +475,6 @@ contract RibbonVault is OptionsVaultStorage {
                 totalSupply(),
                 vaultParams.asset,
                 vaultParams.decimals,
-                vaultParams.initialSharePrice,
                 uint256(vaultState.totalPending),
                 vaultState.queuedWithdrawShares
             );

--- a/test/RibbonDeltaVault.ts
+++ b/test/RibbonDeltaVault.ts
@@ -72,7 +72,6 @@ describe("RibbonDeltaVault", () => {
     optionAllocationPct: BigNumber.from("500"),
     optionPremium: BigNumber.from("1").mul(BigNumber.from("10").pow("8")),
     minimumSupply: BigNumber.from("10").pow("3").toString(),
-    initialSharePrice: BigNumber.from("10").pow("8").toString(),
     expectedMintAmount: BigNumber.from("100000000"),
     auctionDuration: 21600,
     isPut: false,
@@ -99,7 +98,6 @@ describe("RibbonDeltaVault", () => {
     deltaStep: BigNumber.from("100"),
     depositAmount: parseEther("1"),
     minimumSupply: BigNumber.from("10").pow("10").toString(),
-    initialSharePrice: BigNumber.from("10").pow("18").toString(),
     expectedMintAmount: BigNumber.from("100000000"),
     premiumDiscount: BigNumber.from("997"),
     managementFee: BigNumber.from("2000000"),
@@ -135,7 +133,6 @@ describe("RibbonDeltaVault", () => {
     optionAllocationPct: BigNumber.from("500"),
     optionPremium: BigNumber.from("1000").mul(BigNumber.from("10").pow("6")),
     minimumSupply: BigNumber.from("10").pow("3").toString(),
-    initialSharePrice: BigNumber.from("10").pow("6").toString(),
     expectedMintAmount: BigNumber.from("370370"),
     auctionDuration: 21600,
     isPut: true,
@@ -165,7 +162,6 @@ describe("RibbonDeltaVault", () => {
     managementFee: BigNumber.from("2000000"),
     performanceFee: BigNumber.from("20000000"),
     optionAllocationPct: BigNumber.from("500"),
-    initialSharePrice: BigNumber.from("10").pow("6").toString(),
     optionPremium: BigNumber.from("1000").mul(BigNumber.from("10").pow("6")),
     minimumSupply: BigNumber.from("10").pow("3").toString(),
     expectedMintAmount: BigNumber.from("5263157894"),
@@ -232,7 +228,6 @@ function behavesLikeRibbonOptionsVault(params: {
   deltaStep: BigNumber;
   depositAmount: BigNumber;
   minimumSupply: string;
-  initialSharePrice: string;
   expectedMintAmount: BigNumber;
   premiumDiscount: BigNumber;
   managementFee: BigNumber;
@@ -263,7 +258,6 @@ function behavesLikeRibbonOptionsVault(params: {
   let tokenSymbol = params.tokenSymbol;
   let tokenDecimals = params.tokenDecimals;
   let minimumSupply = params.minimumSupply;
-  let initialSharePrice = params.initialSharePrice;
   let asset = params.asset;
   let collateralAsset = params.collateralAsset;
   let depositAmount = params.depositAmount;
@@ -450,7 +444,6 @@ function behavesLikeRibbonOptionsVault(params: {
           asset,
           minimumSupply,
           parseEther("500"),
-          initialSharePrice,
         ],
       ];
 
@@ -506,7 +499,6 @@ function behavesLikeRibbonOptionsVault(params: {
           asset,
           minimumSupply,
           parseEther("500"),
-          initialSharePrice,
         ],
       ];
 
@@ -692,7 +684,6 @@ function behavesLikeRibbonOptionsVault(params: {
           underlying,
           minimumSupply,
           cap,
-          initialSharePrice,
         ] = await vault.vaultParams();
         assert.equal(await decimals, tokenDecimals);
         assert.equal(decimals, tokenDecimals);
@@ -702,7 +693,6 @@ function behavesLikeRibbonOptionsVault(params: {
         assert.equal(await vault.USDC(), USDC_ADDRESS);
         assert.bnEqual(await vault.totalPending(), BigNumber.from(0));
         assert.equal(minimumSupply, params.minimumSupply);
-        assert.equal(initialSharePrice, params.initialSharePrice);
         assert.equal(isPut, params.isPut);
         assert.equal(await vault.counterpartyThetaVault(), thetaVault.address);
         assert.bnEqual(cap, parseEther("500"));
@@ -730,7 +720,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("Initializable: contract is already initialized");
@@ -754,7 +743,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!owner");
@@ -778,7 +766,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!feeRecipient");
@@ -802,7 +789,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               0,
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!cap");
@@ -826,7 +812,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!asset");
@@ -850,7 +835,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               0,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!minimumSupply");
@@ -874,7 +858,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!performanceFee");
@@ -898,7 +881,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!performanceFee");

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -2505,7 +2505,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
           await expect(tx)
             .to.emit(collateralERC20, "Transfer")
-            .withArgs(vault.address, user, depositAmount);
+            .withArgs(vault.address, user, withdrawAmount);
         }
 
         const { shares, round } = await vault.withdrawals(user);

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -72,7 +72,6 @@ describe("RibbonThetaVault", () => {
     managementFee: BigNumber.from("2000000"),
     performanceFee: BigNumber.from("20000000"),
     minimumSupply: BigNumber.from("10").pow("3").toString(),
-    initialSharePrice: BigNumber.from("10").pow("8").mul("2").toString(),
     expectedMintAmount: BigNumber.from("100000000"),
     auctionDuration: 21600,
     isPut: false,
@@ -99,7 +98,6 @@ describe("RibbonThetaVault", () => {
     deltaStep: BigNumber.from("100"),
     depositAmount: parseEther("1"),
     minimumSupply: BigNumber.from("10").pow("10").toString(),
-    initialSharePrice: BigNumber.from("10").pow("18").mul("2").toString(),
     expectedMintAmount: BigNumber.from("100000000"),
     premiumDiscount: BigNumber.from("997"),
     managementFee: BigNumber.from("2000000"),
@@ -130,7 +128,6 @@ describe("RibbonThetaVault", () => {
     managementFee: BigNumber.from("2000000"),
     performanceFee: BigNumber.from("20000000"),
     minimumSupply: BigNumber.from("10").pow("3").toString(),
-    initialSharePrice: BigNumber.from("10").pow("6").mul("2").toString(),
     expectedMintAmount: BigNumber.from("5263157894"),
     auctionDuration: 21600,
     tokenDecimals: 6,
@@ -170,7 +167,6 @@ type Option = {
  * @param {string} params.mintConfig.contractOwnerAddress - Impersonate address of mintable asset contract owner
  * @param {BigNumber} params.depositAmount - Deposit amount
  * @param {string} params.minimumSupply - Minimum supply to maintain for share and asset balance
- * @param {string} params.initialSharePrice - Round 1 asset/share price
  * @param {BigNumber} params.expectedMintAmount - Expected oToken amount to be minted with our deposit
  * @param {number} params.auctionDuration - Duration of gnosis auction in seconds
  * @param {BigNumber} params.premiumDiscount - Premium discount of the sold options to incentivize arbitraguers (thousandths place: 000 - 999)
@@ -193,7 +189,6 @@ function behavesLikeRibbonOptionsVault(params: {
   deltaStep: BigNumber;
   depositAmount: BigNumber;
   minimumSupply: string;
-  initialSharePrice: string;
   expectedMintAmount: BigNumber;
   auctionDuration: number;
   premiumDiscount: BigNumber;
@@ -232,7 +227,6 @@ function behavesLikeRibbonOptionsVault(params: {
   // let expectedMintAmount = params.expectedMintAmount;
   let auctionDuration = params.auctionDuration;
   let isPut = params.isPut;
-  let initialSharePrice = params.initialSharePrice;
 
   // Contracts
   let strikeSelection: Contract;
@@ -392,7 +386,6 @@ function behavesLikeRibbonOptionsVault(params: {
           asset,
           minimumSupply,
           parseEther("500"),
-          initialSharePrice,
         ],
       ];
 
@@ -578,7 +571,6 @@ function behavesLikeRibbonOptionsVault(params: {
           underlying,
           minimumSupply,
           cap,
-          initialSharePrice,
         ] = await vault.vaultParams();
         assert.equal(await decimals, tokenDecimals);
         assert.equal(decimals, tokenDecimals);
@@ -589,7 +581,6 @@ function behavesLikeRibbonOptionsVault(params: {
         assert.bnEqual(await vault.totalPending(), BigNumber.from(0));
         assert.equal(minimumSupply, params.minimumSupply);
         assert.equal(isPut, params.isPut);
-        assert.equal(initialSharePrice, params.initialSharePrice);
         assert.equal(
           (await vault.premiumDiscount()).toString(),
           params.premiumDiscount.toString()
@@ -623,7 +614,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("Initializable: contract is already initialized");
@@ -649,7 +639,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!owner");
@@ -675,7 +664,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!feeRecipient");
@@ -701,7 +689,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               0,
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!cap");
@@ -727,7 +714,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!asset");
@@ -753,7 +739,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               0,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!minimumSupply");
@@ -779,7 +764,6 @@ function behavesLikeRibbonOptionsVault(params: {
               asset,
               minimumSupply,
               parseEther("500"),
-              initialSharePrice,
             ]
           )
         ).to.be.revertedWith("!performanceFee");
@@ -1172,10 +1156,6 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await vault.deposit(params.depositAmount);
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
         assert.bnEqual(
           await assetContract.balanceOf(vault.address),
           params.depositAmount
@@ -1183,7 +1163,7 @@ function behavesLikeRibbonOptionsVault(params: {
         // vault will still hold the vault shares
         assert.bnEqual(
           await vault.balanceOf(vault.address),
-          expectedShareBalance
+          params.depositAmount
         );
 
         const {
@@ -1196,7 +1176,7 @@ function behavesLikeRibbonOptionsVault(params: {
         assert.isFalse(processed3);
         assert.equal(round3, 2);
         assert.bnEqual(amount3, params.depositAmount);
-        assert.bnEqual(unredeemedShares3, expectedShareBalance);
+        assert.bnEqual(unredeemedShares3, params.depositAmount);
       });
     });
 
@@ -1955,22 +1935,18 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
         const tx = await vault.maxRedeem();
 
         assert.bnEqual(
           await assetContract.balanceOf(vault.address),
           BigNumber.from(0)
         );
-        assert.bnEqual(await vault.balanceOf(user), expectedShareBalance);
+        assert.bnEqual(await vault.balanceOf(user), params.depositAmount);
         assert.bnEqual(await vault.balanceOf(vault.address), BigNumber.from(0));
 
         await expect(tx)
           .to.emit(vault, "Redeem")
-          .withArgs(user, expectedShareBalance, 1);
+          .withArgs(user, params.depositAmount, 1);
 
         const { round, amount, unredeemedShares } = await vault.depositReceipts(
           user
@@ -1995,7 +1971,7 @@ function behavesLikeRibbonOptionsVault(params: {
         await expect(vault.maxRedeem()).to.be.revertedWith("!shares");
       });
 
-      it("reverts when redeeming after implicit redemption", async function () {
+      it("redeems after a deposit what was unredeemed from previous rounds", async function () {
         await assetContract
           .connect(userSigner)
           .approve(vault.address, params.depositAmount.mul(2));
@@ -2006,7 +1982,11 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await vault.deposit(params.depositAmount);
 
-        await expect(vault.maxRedeem()).to.be.revertedWith("Round not closed");
+        const tx = await vault.maxRedeem();
+
+        await expect(tx)
+          .to.emit(vault, "Redeem")
+          .withArgs(user, params.depositAmount, 2);
       });
 
       it("is able to redeem deposit at correct pricePerShare after closing short in the money", async function () {
@@ -2017,10 +1997,6 @@ function behavesLikeRibbonOptionsVault(params: {
         await assetContract
           .connect(ownerSigner)
           .approve(vault.address, params.depositAmount);
-
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
 
         // Mid-week deposit in round 1
         await assetContract
@@ -2076,7 +2052,7 @@ function behavesLikeRibbonOptionsVault(params: {
         const tx1 = await vault.connect(ownerSigner).maxRedeem();
         await expect(tx1)
           .to.emit(vault, "Redeem")
-          .withArgs(owner, expectedShareBalance, 1);
+          .withArgs(owner, params.depositAmount, 1);
 
         const {
           round: round1,
@@ -2086,7 +2062,7 @@ function behavesLikeRibbonOptionsVault(params: {
         assert.equal(round1, 1);
         assert.bnEqual(amount1, BigNumber.from(0));
         assert.bnEqual(unredeemedShares1, BigNumber.from(0));
-        assert.bnEqual(await vault.balanceOf(owner), expectedShareBalance);
+        assert.bnEqual(await vault.balanceOf(owner), params.depositAmount);
 
         // User deposit in round 2 so no loss
         // we should use the pps after the loss which is the lower pps
@@ -2162,10 +2138,6 @@ function behavesLikeRibbonOptionsVault(params: {
           .to.emit(vault, "Redeem")
           .withArgs(user, redeemAmount, 1);
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
         const {
           round: round1,
           amount: amount1,
@@ -2174,16 +2146,13 @@ function behavesLikeRibbonOptionsVault(params: {
 
         assert.equal(round1, 1);
         assert.bnEqual(amount1, BigNumber.from(0));
-        assert.bnEqual(
-          unredeemedShares1,
-          expectedShareBalance.sub(redeemAmount)
-        );
+        assert.bnEqual(unredeemedShares1, depositAmount.sub(redeemAmount));
 
-        const tx2 = await vault.redeem(expectedShareBalance.sub(redeemAmount));
+        const tx2 = await vault.redeem(depositAmount.sub(redeemAmount));
 
         await expect(tx2)
           .to.emit(vault, "Redeem")
-          .withArgs(user, expectedShareBalance.sub(redeemAmount), 1);
+          .withArgs(user, depositAmount.sub(redeemAmount), 1);
 
         const {
           round: round2,
@@ -2344,11 +2313,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
-        await vault.initiateWithdraw(expectedShareBalance.div(2));
+        await vault.initiateWithdraw(depositAmount.div(2));
 
         await setOpynOracleExpiryPrice(
           params.asset,
@@ -2362,7 +2327,7 @@ function behavesLikeRibbonOptionsVault(params: {
         await vault.connect(ownerSigner).rollToNextOption();
 
         await expect(
-          vault.initiateWithdraw(expectedShareBalance.div(2))
+          vault.initiateWithdraw(depositAmount.div(2))
         ).to.be.revertedWith("Existing withdraw");
       });
 
@@ -2374,23 +2339,19 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
-        const tx = await vault.initiateWithdraw(expectedShareBalance);
+        const tx = await vault.initiateWithdraw(depositAmount);
 
         await expect(tx)
           .to.emit(vault, "InitiateWithdraw")
-          .withArgs(user, expectedShareBalance, 2);
+          .withArgs(user, depositAmount, 2);
 
         await expect(tx)
           .to.emit(vault, "Transfer")
-          .withArgs(vault.address, user, expectedShareBalance);
+          .withArgs(vault.address, user, depositAmount);
 
         const { round, shares } = await vault.withdrawals(user);
         assert.equal(round, 2);
-        assert.bnEqual(shares, expectedShareBalance);
+        assert.bnEqual(shares, depositAmount);
       });
 
       it("creates withdrawal by debiting user shares", async function () {
@@ -2401,37 +2362,30 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
+        await vault.redeem(depositAmount.div(2));
 
-        await vault.redeem(expectedShareBalance.div(2));
-
-        const tx = await vault.initiateWithdraw(expectedShareBalance);
+        const tx = await vault.initiateWithdraw(depositAmount);
 
         await expect(tx)
           .to.emit(vault, "InitiateWithdraw")
-          .withArgs(user, expectedShareBalance, 2);
+          .withArgs(user, depositAmount, 2);
 
         // First we redeem the leftover amount
         await expect(tx)
           .to.emit(vault, "Transfer")
-          .withArgs(vault.address, user, expectedShareBalance.div(2));
+          .withArgs(vault.address, user, depositAmount.div(2));
 
         // Then we debit the shares from the user
         await expect(tx)
           .to.emit(vault, "Transfer")
-          .withArgs(user, vault.address, expectedShareBalance);
+          .withArgs(user, vault.address, depositAmount);
 
         assert.bnEqual(await vault.balanceOf(user), BigNumber.from(0));
-        assert.bnEqual(
-          await vault.balanceOf(vault.address),
-          expectedShareBalance
-        );
+        assert.bnEqual(await vault.balanceOf(vault.address), depositAmount);
 
         const { round, shares } = await vault.withdrawals(user);
         assert.equal(round, 2);
-        assert.bnEqual(shares, expectedShareBalance);
+        assert.bnEqual(shares, depositAmount);
       });
 
       it("tops up existing withdrawal", async function () {
@@ -2442,27 +2396,40 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
-        const tx1 = await vault.initiateWithdraw(expectedShareBalance.div(2));
+        const tx1 = await vault.initiateWithdraw(depositAmount.div(2));
         // We redeem the full amount on the first initiateWithdraw
         await expect(tx1)
           .to.emit(vault, "Transfer")
-          .withArgs(vault.address, user, expectedShareBalance);
+          .withArgs(vault.address, user, depositAmount);
         await expect(tx1)
           .to.emit(vault, "Transfer")
-          .withArgs(user, vault.address, expectedShareBalance.div(2));
+          .withArgs(user, vault.address, depositAmount.div(2));
 
-        const tx2 = await vault.initiateWithdraw(expectedShareBalance.div(2));
+        const tx2 = await vault.initiateWithdraw(depositAmount.div(2));
         await expect(tx2)
           .to.emit(vault, "Transfer")
-          .withArgs(user, vault.address, expectedShareBalance.div(2));
+          .withArgs(user, vault.address, depositAmount.div(2));
 
         const { round, shares } = await vault.withdrawals(user);
         assert.equal(round, 2);
-        assert.bnEqual(shares, expectedShareBalance);
+        assert.bnEqual(shares, depositAmount);
+      });
+
+      it("can initiate a withdrawal when there is a pending deposit", async function () {
+        await assetContract
+          .connect(userSigner)
+          .approve(vault.address, depositAmount.mul(2));
+        await vault.deposit(depositAmount);
+
+        await rollToNextOption();
+
+        await vault.deposit(depositAmount);
+
+        const tx = await vault.initiateWithdraw(depositAmount);
+
+        await expect(tx)
+          .to.emit(vault, "Redeem")
+          .withArgs(user, depositAmount, 2);
       });
 
       it("reverts when there is insufficient balance over multiple calls", async function () {
@@ -2487,11 +2454,8 @@ function behavesLikeRibbonOptionsVault(params: {
         await vault.deposit(depositAmount);
 
         await rollToNextOption();
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
 
-        const tx = await vault.initiateWithdraw(expectedShareBalance);
+        const tx = await vault.initiateWithdraw(depositAmount);
         const receipt = await tx.wait();
         assert.isAtMost(receipt.gasUsed.toNumber(), 104000);
         // console.log("initiateWithdraw", receipt.gasUsed.toNumber());
@@ -2504,9 +2468,6 @@ function behavesLikeRibbonOptionsVault(params: {
           .connect(userSigner)
           .approve(vault.address, depositAmount);
         await vault.deposit(depositAmount);
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
 
         await assetContract.connect(userSigner).transfer(owner, depositAmount);
         await assetContract
@@ -2516,7 +2477,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        await vault.initiateWithdraw(expectedShareBalance);
+        await vault.initiateWithdraw(depositAmount);
       });
 
       it("reverts when not initiated", async function () {
@@ -2547,14 +2508,10 @@ function behavesLikeRibbonOptionsVault(params: {
           ? firstStrikePrice.sub(100000000)
           : firstStrikePrice.add(100000000);
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
         await rollToSecondOption(settlePriceITM);
 
         const pricePerShare = await vault.roundPricePerShare(2);
-        const withdrawAmount = expectedShareBalance
+        const withdrawAmount = depositAmount
           .mul(pricePerShare)
           .div(BigNumber.from(10).pow(await vault.decimals()));
 
@@ -2574,7 +2531,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await expect(tx)
           .to.emit(vault, "Withdraw")
-          .withArgs(user, withdrawAmount.toString(), expectedShareBalance);
+          .withArgs(user, withdrawAmount.toString(), depositAmount);
 
         if (collateralAsset !== WETH_ADDRESS) {
           const collateralERC20 = await getContractAt(
@@ -2584,7 +2541,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
           await expect(tx)
             .to.emit(collateralERC20, "Transfer")
-            .withArgs(vault.address, user, withdrawAmount);
+            .withArgs(vault.address, user, depositAmount);
         }
 
         const { shares, round } = await vault.withdrawals(user);
@@ -2595,10 +2552,7 @@ function behavesLikeRibbonOptionsVault(params: {
           await vault.vaultState();
 
         assert.bnEqual(endQueuedShares, BigNumber.from(0));
-        assert.bnEqual(
-          startQueuedShares.sub(endQueuedShares),
-          expectedShareBalance
-        );
+        assert.bnEqual(startQueuedShares.sub(endQueuedShares), depositAmount);
 
         let actualWithdrawAmount: BigNumber;
         if (collateralAsset === WETH_ADDRESS) {
@@ -2689,24 +2643,20 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
-        assert.bnEqual(await vault.shares(user), expectedShareBalance);
+        assert.bnEqual(await vault.shares(user), depositAmount);
 
         const redeemAmount = BigNumber.from(1);
         await vault.redeem(redeemAmount);
 
         // Share balance should remain the same because the 1 share
         // is transferred to the user
-        assert.bnEqual(await vault.shares(user), expectedShareBalance);
+        assert.bnEqual(await vault.shares(user), depositAmount);
 
         await vault.transfer(owner, redeemAmount);
 
         assert.bnEqual(
           await vault.shares(user),
-          expectedShareBalance.sub(redeemAmount)
+          depositAmount.sub(redeemAmount)
         );
         assert.bnEqual(await vault.shares(owner), redeemAmount);
       });
@@ -2723,18 +2673,14 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
         const [heldByAccount1, heldByVault1] = await vault.shareBalances(user);
         assert.bnEqual(heldByAccount1, BigNumber.from(0));
-        assert.bnEqual(heldByVault1, expectedShareBalance);
+        assert.bnEqual(heldByVault1, depositAmount);
 
         await vault.redeem(1);
         const [heldByAccount2, heldByVault2] = await vault.shareBalances(user);
         assert.bnEqual(heldByAccount2, BigNumber.from(1));
-        assert.bnEqual(heldByVault2, expectedShareBalance.sub(1));
+        assert.bnEqual(heldByVault2, depositAmount.sub(1));
       });
     });
 
@@ -2749,15 +2695,11 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const expectedShareBalance = params.depositAmount
-          .mul(BigNumber.from(10).pow(await vault.decimals()))
-          .div(params.initialSharePrice);
-
-        assert.bnEqual(await vault.shares(user), expectedShareBalance);
+        assert.bnEqual(await vault.shares(user), depositAmount);
 
         // Should remain the same after redemption because it's held on balanceOf
         await vault.redeem(1);
-        assert.bnEqual(await vault.shares(user), expectedShareBalance);
+        assert.bnEqual(await vault.shares(user), depositAmount);
       });
     });
 

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -2396,24 +2396,6 @@ function behavesLikeRibbonOptionsVault(params: {
         assert.equal(round, 2);
         assert.bnEqual(shares, depositAmount);
       });
-
-      it("can initiate a withdrawal when there is a pending deposit", async function () {
-        await assetContract
-          .connect(userSigner)
-          .approve(vault.address, depositAmount.mul(2));
-        await vault.deposit(depositAmount);
-
-        await rollToNextOption();
-
-        await vault.deposit(depositAmount);
-
-        const tx = await vault.initiateWithdraw(depositAmount);
-
-        await expect(tx)
-          .to.emit(vault, "Redeem")
-          .withArgs(user, depositAmount, 2);
-      });
-
       it("reverts when there is insufficient balance over multiple calls", async function () {
         await assetContract
           .connect(userSigner)

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1971,24 +1971,6 @@ function behavesLikeRibbonOptionsVault(params: {
         await expect(vault.maxRedeem()).to.be.revertedWith("!shares");
       });
 
-      it("redeems after a deposit what was unredeemed from previous rounds", async function () {
-        await assetContract
-          .connect(userSigner)
-          .approve(vault.address, params.depositAmount.mul(2));
-
-        await vault.deposit(params.depositAmount);
-
-        await rollToNextOption();
-
-        await vault.deposit(params.depositAmount);
-
-        const tx = await vault.maxRedeem();
-
-        await expect(tx)
-          .to.emit(vault, "Redeem")
-          .withArgs(user, params.depositAmount, 2);
-      });
-
       it("is able to redeem deposit at correct pricePerShare after closing short in the money", async function () {
         await assetContract
           .connect(userSigner)

--- a/test/libraries/VaultLifecycle.ts
+++ b/test/libraries/VaultLifecycle.ts
@@ -1,7 +1,8 @@
 import { ethers } from "hardhat";
-import { Contract } from "ethers";
+import { BigNumber, Contract } from "ethers";
 import moment from "moment-timezone";
 import { assert } from "../helpers/assertions";
+import { parseEther } from "ethers/lib/utils";
 
 moment.tz.setDefault("UTC");
 
@@ -11,8 +12,12 @@ describe("VaultLifecycle", () => {
   let lifecycle: Contract;
 
   before(async () => {
+    const VaultLifecycle = await ethers.getContractFactory("VaultLifecycle");
+    const lifecycleLib = await VaultLifecycle.deploy();
+
     const TestVaultLifecycle = await ethers.getContractFactory(
-      "TestVaultLifecycle"
+      "TestVaultLifecycle",
+      { libraries: { VaultLifecycle: lifecycleLib.address } }
     );
     lifecycle = await TestVaultLifecycle.deploy();
   });
@@ -112,6 +117,35 @@ describe("VaultLifecycle", () => {
       const fridayDate = moment.unix(nextFriday);
       assert.equal(fridayDate.weekday(), 5);
       assert.isTrue(fridayDate.isSame(expectedFriday));
+    });
+  });
+
+  describe("rollover", () => {
+    it("rolls over with correct math", async () => {
+      const [lockedAmount, pricePerShare, mintShares] =
+        await lifecycle.rollover(
+          parseEther("1"),
+          lifecycle.address, // pass in the lifecycle contract itself as the address to mock
+          18,
+          parseEther("0.1"),
+          parseEther("0.1")
+        );
+
+      // currentBalance - lockedAmount = queuedWithdrawAmount
+      const queuedWithdrawAmount = parseEther("1").sub(lockedAmount);
+
+      const singleShare = BigNumber.from(10).pow(18);
+
+      // (1 ether - 0.1 ether)/1 ether
+      assert.bnEqual(pricePerShare, parseEther("0.9"));
+      assert.bnEqual(
+        mintShares,
+        parseEther("0.1").mul(singleShare).div(pricePerShare)
+      );
+      assert.bnEqual(
+        queuedWithdrawAmount,
+        parseEther("0.1").mul(pricePerShare).div(singleShare)
+      );
     });
   });
 });

--- a/test/libraries/VaultLifecycle.ts
+++ b/test/libraries/VaultLifecycle.ts
@@ -128,7 +128,7 @@ describe("VaultLifecycle", () => {
           lifecycle.address, // pass in the lifecycle contract itself as the address to mock
           18,
           parseEther("0.1"),
-          parseEther("0.1")
+          parseEther("0.2")
         );
 
       // currentBalance - lockedAmount = queuedWithdrawAmount
@@ -144,7 +144,7 @@ describe("VaultLifecycle", () => {
       );
       assert.bnEqual(
         queuedWithdrawAmount,
-        parseEther("0.1").mul(pricePerShare).div(singleShare)
+        parseEther("0.2").mul(pricePerShare).div(singleShare)
       );
     });
   });

--- a/test/libraries/VaultLifecycle.ts
+++ b/test/libraries/VaultLifecycle.ts
@@ -128,7 +128,7 @@ describe("VaultLifecycle", () => {
           lifecycle.address, // pass in the lifecycle contract itself as the address to mock
           18,
           parseEther("0.1"),
-          parseEther("0.2")
+          parseEther("0.1")
         );
 
       // currentBalance - lockedAmount = queuedWithdrawAmount
@@ -144,7 +144,7 @@ describe("VaultLifecycle", () => {
       );
       assert.bnEqual(
         queuedWithdrawAmount,
-        parseEther("0.2").mul(pricePerShare).div(singleShare)
+        parseEther("0.1").mul(pricePerShare).div(singleShare)
       );
     });
   });


### PR DESCRIPTION
The refactored calculations for `mintShares` and `queuedWithdrawAmount` are logically equivalent with the previous calculation. But it's more readable and uses the ShareMath lib