### PR TITLE
Chainsafe fixes

### DIFF
--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -251,10 +251,12 @@ library VaultLifecycle {
                 .div(oToken.strikePrice().mul(10**(10 + collateralDecimals)));
         } else {
             mintAmount = depositAmount;
-            uint256 scaleBy = 10**(collateralDecimals.sub(8)); // oTokens have 8 decimals
 
-            if (mintAmount > scaleBy && collateralDecimals > 8) {
-                mintAmount = depositAmount.div(scaleBy); // scale down from 10**18 to 10**8
+            if (collateralDecimals > 8) {
+                uint256 scaleBy = 10**(collateralDecimals.sub(8)); // oTokens have 8 decimals
+                if (mintAmount > scaleBy) {
+                    mintAmount = depositAmount.div(scaleBy); // scale down from 10**18 to 10**8
+                }
             }
         }
 
@@ -291,7 +293,7 @@ library VaultLifecycle {
             IController.ActionType.MintShortOption,
             address(this), // owner
             address(this), // address to transfer to
-            oTokenAddress, // deposited asset
+            oTokenAddress, // option address
             newVaultID, // vaultId
             mintAmount, // amount
             0, //index

--- a/contracts/libraries/VaultLifecycleSTETH.sol
+++ b/contracts/libraries/VaultLifecycleSTETH.sol
@@ -196,13 +196,13 @@ library VaultLifecycleSTETH {
         uint256 mintAmount;
 
         mintAmount = depositAmount;
-        uint256 scaleBy = 10**(collateralDecimals.sub(8)); // oTokens have 8 decimals
-
-        if (mintAmount > scaleBy && collateralDecimals > 8) {
-            mintAmount = depositAmount.div(scaleBy); // scale down from 10**18 to 10**8
+        if (collateralDecimals > 8) {
+            uint256 scaleBy = 10**(collateralDecimals.sub(8)); // oTokens have 8 decimals
+            if (mintAmount > scaleBy) {
+                mintAmount = depositAmount.div(scaleBy); // scale down from 10**18 to 10**8
+            }
         }
 
-        // double approve to fix non-compliant ERC20s
         IERC20 collateralToken = IERC20(collateralAsset);
         collateralToken.safeApprove(marginPool, depositAmount);
 
@@ -235,7 +235,7 @@ library VaultLifecycleSTETH {
             IController.ActionType.MintShortOption,
             address(this), // owner
             address(this), // address to transfer to
-            oTokenAddress, // deposited asset
+            oTokenAddress, // option address
             newVaultID, // vaultId
             mintAmount, // amount
             0, //index

--- a/contracts/vaults/BaseVaults/RibbonThetaVault.sol
+++ b/contracts/vaults/BaseVaults/RibbonThetaVault.sol
@@ -330,7 +330,7 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
      */
     function _closeShort(address oldOption) private {
         uint256 lockedAmount = vaultState.lockedAmount;
-        if (optionState.currentOption != address(0)) {
+        if (oldOption != address(0)) {
             vaultState.lastLockedAmount = uint104(lockedAmount);
         }
         vaultState.lockedAmount = 0;

--- a/contracts/vaults/BaseVaults/RibbonThetaVault.sol
+++ b/contracts/vaults/BaseVaults/RibbonThetaVault.sol
@@ -329,11 +329,13 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
      * @notice Closes the existing short position for the vault.
      */
     function _closeShort(address oldOption) private {
-        optionState.currentOption = address(0);
-
         uint256 lockedAmount = vaultState.lockedAmount;
-        vaultState.lastLockedAmount = uint104(lockedAmount);
+        if (optionState.currentOption != address(0)) {
+            vaultState.lastLockedAmount = uint104(lockedAmount);
+        }
         vaultState.lockedAmount = 0;
+
+        optionState.currentOption = address(0);
 
         if (oldOption != address(0)) {
             uint256 withdrawAmount =
@@ -397,14 +399,14 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
      * @notice Burn the remaining oTokens left over from gnosis auction.
      */
     function burnRemainingOTokens() external onlyKeeper nonReentrant {
-        uint256 unlockedAssedAmount =
+        uint256 unlockedAssetAmount =
             VaultLifecycle.burnOtokens(
                 GAMMA_CONTROLLER,
                 optionState.currentOption
             );
 
         vaultState.lockedAmount = uint104(
-            uint256(vaultState.lockedAmount).sub(unlockedAssedAmount)
+            uint256(vaultState.lockedAmount).sub(unlockedAssetAmount)
         );
     }
 }

--- a/contracts/vaults/BaseVaults/base/RibbonVault.sol
+++ b/contracts/vaults/BaseVaults/base/RibbonVault.sol
@@ -127,7 +127,7 @@ contract RibbonVault is
 
     event PerformanceFeeSet(uint256 performanceFee, uint256 newPerformanceFee);
 
-    event CapSet(uint256 oldCap, uint256 newCap, address manager);
+    event CapSet(uint256 oldCap, uint256 newCap);
 
     event Withdraw(address indexed account, uint256 amount, uint256 shares);
 
@@ -258,9 +258,12 @@ contract RibbonVault is
         );
 
         // We are dividing annualized management fee by num weeks in a year
-        managementFee = newManagementFee.mul(Vault.FEE_MULTIPLIER).div(
-            WEEKS_PER_YEAR
-        );
+        uint256 tmpManagementFee =
+            newManagementFee.mul(Vault.FEE_MULTIPLIER).div(WEEKS_PER_YEAR);
+
+        emit ManagementFeeSet(managementFee, newManagementFee);
+
+        managementFee = tmpManagementFee;
     }
 
     /**
@@ -285,6 +288,7 @@ contract RibbonVault is
     function setCap(uint256 newCap) external onlyOwner {
         require(newCap > 0, "!newCap");
         ShareMath.assertUint104(newCap);
+        emit CapSet(vaultParams.cap, newCap);
         vaultParams.cap = uint104(newCap);
     }
 

--- a/contracts/vaults/BaseVaults/base/RibbonVault.sol
+++ b/contracts/vaults/BaseVaults/base/RibbonVault.sol
@@ -526,9 +526,9 @@ contract RibbonVault is
         // If we have a depositReceipt on the same round, BUT we have some unredeemed shares
         // we debit from the unredeemedShares, but leave the amount field intact
         // If the round has past, with no new deposits, we just zero it out for new deposits.
-        depositReceipts[msg.sender].amount = depositReceipt.round < currentRound
-            ? 0
-            : depositReceipt.amount;
+        if (depositReceipt.round < currentRound) {
+            depositReceipts[msg.sender].amount = 0;
+        }
 
         ShareMath.assertUint128(numShares);
         depositReceipts[msg.sender].unredeemedShares = uint128(
@@ -556,7 +556,6 @@ contract RibbonVault is
         uint256 _round = vaultState.round;
         for (uint256 i = 0; i < numRounds; i++) {
             uint256 index = _round + i;
-            require(index >= _round, "Overflow");
             require(roundPricePerShare[index] == 0, "Initialized"); // AVOID OVERWRITING ACTUAL VALUES
             roundPricePerShare[index] = ShareMath.PLACEHOLDER_UINT;
         }

--- a/contracts/vaults/STETHVault/RibbonThetaSTETHVault.sol
+++ b/contracts/vaults/STETHVault/RibbonThetaSTETHVault.sol
@@ -334,11 +334,13 @@ contract RibbonThetaSTETHVault is RibbonVault, RibbonThetaSTETHVaultStorage {
      * @notice Closes the existing short position for the vault.
      */
     function _closeShort(address oldOption) private {
-        optionState.currentOption = address(0);
-
         uint256 lockedAmount = vaultState.lockedAmount;
-        vaultState.lastLockedAmount = uint104(lockedAmount);
+        if (optionState.currentOption != address(0)) {
+            vaultState.lastLockedAmount = uint104(lockedAmount);
+        }
         vaultState.lockedAmount = 0;
+
+        optionState.currentOption = address(0);
 
         if (oldOption != address(0)) {
             uint256 withdrawAmount =
@@ -402,14 +404,14 @@ contract RibbonThetaSTETHVault is RibbonVault, RibbonThetaSTETHVaultStorage {
      * @notice Burn the remaining oTokens left over from gnosis auction.
      */
     function burnRemainingOTokens() external onlyKeeper nonReentrant {
-        uint256 unlockedAssedAmount =
+        uint256 unlockedAssetAmount =
             VaultLifecycle.burnOtokens(
                 GAMMA_CONTROLLER,
                 optionState.currentOption
             );
 
         vaultState.lockedAmount = uint104(
-            uint256(vaultState.lockedAmount).sub(unlockedAssedAmount)
+            uint256(vaultState.lockedAmount).sub(unlockedAssetAmount)
         );
 
         // Wrap entire `asset` balance to `collateralToken` balance

--- a/contracts/vaults/STETHVault/RibbonThetaSTETHVault.sol
+++ b/contracts/vaults/STETHVault/RibbonThetaSTETHVault.sol
@@ -335,7 +335,7 @@ contract RibbonThetaSTETHVault is RibbonVault, RibbonThetaSTETHVaultStorage {
      */
     function _closeShort(address oldOption) private {
         uint256 lockedAmount = vaultState.lockedAmount;
-        if (optionState.currentOption != address(0)) {
+        if (oldOption != address(0)) {
             vaultState.lastLockedAmount = uint104(lockedAmount);
         }
         vaultState.lockedAmount = 0;

--- a/contracts/vaults/STETHVault/base/RibbonVault.sol
+++ b/contracts/vaults/STETHVault/base/RibbonVault.sol
@@ -135,7 +135,7 @@ contract RibbonVault is
 
     event ManagementFeeSet(uint256 managementFee, uint256 newManagementFee);
     event PerformanceFeeSet(uint256 performanceFee, uint256 newPerformanceFee);
-    event CapSet(uint256 oldCap, uint256 newCap, address manager);
+    event CapSet(uint256 oldCap, uint256 newCap);
 
     event Withdraw(address indexed account, uint256 amount, uint256 shares);
 
@@ -279,9 +279,12 @@ contract RibbonVault is
         );
 
         // We are dividing annualized management fee by num weeks in a year
-        managementFee = newManagementFee.mul(Vault.FEE_MULTIPLIER).div(
-            WEEKS_PER_YEAR
-        );
+        uint256 tmpManagementFee =
+            newManagementFee.mul(Vault.FEE_MULTIPLIER).div(WEEKS_PER_YEAR);
+
+        emit ManagementFeeSet(managementFee, newManagementFee);
+
+        managementFee = tmpManagementFee;
     }
 
     /**
@@ -304,6 +307,7 @@ contract RibbonVault is
     function setCap(uint256 newCap) external onlyOwner {
         require(newCap > 0, "!newCap");
         ShareMath.assertUint104(newCap);
+        emit CapSet(vaultParams.cap, newCap);
         vaultParams.cap = uint104(newCap);
     }
 

--- a/contracts/vaults/STETHVault/base/RibbonVault.sol
+++ b/contracts/vaults/STETHVault/base/RibbonVault.sol
@@ -154,7 +154,7 @@ contract RibbonVault is
      * @notice Initializes the contract with immutable variables
      * @param _weth is the Wrapped Ether contract
      * @param _usdc is the USDC contract
-     * @param _wsteth is the LDO contract
+     * @param _wsteth is the wstETH contract
      * @param _ldo is the LDO contract
      * @param _gammaController is the contract address for opyn actions
      * @param _marginPool is the contract address for providing collateral to opyn
@@ -547,9 +547,9 @@ contract RibbonVault is
         // If we have a depositReceipt on the same round, BUT we have some unredeemed shares
         // we debit from the unredeemedShares, but leave the amount field intact
         // If the round has past, with no new deposits, we just zero it out for new deposits.
-        depositReceipts[msg.sender].amount = depositReceipt.round < currentRound
-            ? 0
-            : depositReceipt.amount;
+        if (depositReceipt.round < currentRound) {
+            depositReceipts[msg.sender].amount = 0;
+        }
 
         ShareMath.assertUint128(numShares);
         depositReceipts[msg.sender].unredeemedShares = uint128(
@@ -577,7 +577,6 @@ contract RibbonVault is
         uint256 _round = vaultState.round;
         for (uint256 i = 0; i < numRounds; i++) {
             uint256 index = _round + i;
-            require(index >= _round, "Overflow");
             require(roundPricePerShare[index] == 0, "Initialized"); // AVOID OVERWRITING ACTUAL VALUES
             roundPricePerShare[index] = ShareMath.PLACEHOLDER_UINT;
         }

--- a/contracts/vaults/YearnVaults/RibbonThetaYearnVault.sol
+++ b/contracts/vaults/YearnVaults/RibbonThetaYearnVault.sol
@@ -336,7 +336,7 @@ contract RibbonThetaYearnVault is RibbonVault, RibbonThetaYearnVaultStorage {
      */
     function _closeShort(address oldOption) private {
         uint256 lockedAmount = vaultState.lockedAmount;
-        if (optionState.currentOption != address(0)) {
+        if (oldOption != address(0)) {
             vaultState.lastLockedAmount = uint104(lockedAmount);
         }
         vaultState.lockedAmount = 0;

--- a/contracts/vaults/YearnVaults/RibbonThetaYearnVault.sol
+++ b/contracts/vaults/YearnVaults/RibbonThetaYearnVault.sol
@@ -335,11 +335,13 @@ contract RibbonThetaYearnVault is RibbonVault, RibbonThetaYearnVaultStorage {
      * @notice Closes the existing short position for the vault.
      */
     function _closeShort(address oldOption) private {
-        optionState.currentOption = address(0);
-
         uint256 lockedAmount = vaultState.lockedAmount;
-        vaultState.lastLockedAmount = uint104(lockedAmount);
+        if (optionState.currentOption != address(0)) {
+            vaultState.lastLockedAmount = uint104(lockedAmount);
+        }
         vaultState.lockedAmount = 0;
+
+        optionState.currentOption = address(0);
 
         if (oldOption != address(0)) {
             uint256 withdrawAmount =
@@ -423,14 +425,14 @@ contract RibbonThetaYearnVault is RibbonVault, RibbonThetaYearnVaultStorage {
      * @notice Burn the remaining oTokens left over from gnosis auction.
      */
     function burnRemainingOTokens() external onlyKeeper nonReentrant {
-        uint256 unlockedAssedAmount =
+        uint256 unlockedAssetAmount =
             VaultLifecycle.burnOtokens(
                 GAMMA_CONTROLLER,
                 optionState.currentOption
             );
 
         vaultState.lockedAmount = uint104(
-            uint256(vaultState.lockedAmount).sub(unlockedAssedAmount)
+            uint256(vaultState.lockedAmount).sub(unlockedAssetAmount)
         );
 
         // Wrap entire `asset` balance to `collateralToken` balance

--- a/contracts/vaults/YearnVaults/base/RibbonVault.sol
+++ b/contracts/vaults/YearnVaults/base/RibbonVault.sol
@@ -559,9 +559,9 @@ contract RibbonVault is
         // If we have a depositReceipt on the same round, BUT we have some unredeemed shares
         // we debit from the unredeemedShares, but leave the amount field intact
         // If the round has past, with no new deposits, we just zero it out for new deposits.
-        depositReceipts[msg.sender].amount = depositReceipt.round < currentRound
-            ? 0
-            : depositReceipt.amount;
+        if (depositReceipt.round < currentRound) {
+            depositReceipts[msg.sender].amount = 0;
+        }
 
         ShareMath.assertUint128(numShares);
 
@@ -590,7 +590,6 @@ contract RibbonVault is
         uint256 _round = vaultState.round;
         for (uint256 i = 0; i < numRounds; i++) {
             uint256 index = _round + i;
-            require(index >= _round, "Overflow");
             require(roundPricePerShare[index] == 0, "Initialized"); // AVOID OVERWRITING ACTUAL VALUES
             roundPricePerShare[index] = ShareMath.PLACEHOLDER_UINT;
         }

--- a/contracts/vaults/YearnVaults/base/RibbonVault.sol
+++ b/contracts/vaults/YearnVaults/base/RibbonVault.sol
@@ -141,7 +141,7 @@ contract RibbonVault is
 
     event PerformanceFeeSet(uint256 performanceFee, uint256 newPerformanceFee);
 
-    event CapSet(uint256 oldCap, uint256 newCap, address manager);
+    event CapSet(uint256 oldCap, uint256 newCap);
 
     event Withdraw(address indexed account, uint256 amount, uint256 shares);
 
@@ -275,10 +275,14 @@ contract RibbonVault is
             newManagementFee < 100 * Vault.FEE_MULTIPLIER,
             "Invalid management fee"
         );
+
         // We are dividing annualized management fee by num weeks in a year
-        managementFee = newManagementFee.mul(Vault.FEE_MULTIPLIER).div(
-            WEEKS_PER_YEAR
-        );
+        uint256 tmpManagementFee =
+            newManagementFee.mul(Vault.FEE_MULTIPLIER).div(WEEKS_PER_YEAR);
+
+        emit ManagementFeeSet(managementFee, newManagementFee);
+
+        managementFee = tmpManagementFee;
     }
 
     /**
@@ -301,6 +305,7 @@ contract RibbonVault is
     function setCap(uint256 newCap) external onlyOwner {
         require(newCap > 0, "!newCap");
         ShareMath.assertUint104(newCap);
+        emit CapSet(vaultParams.cap, newCap);
         vaultParams.cap = uint104(newCap);
     }
 

--- a/test/RibbonThetaSTETHVault.ts
+++ b/test/RibbonThetaSTETHVault.ts
@@ -1310,6 +1310,7 @@ function behavesLikeRibbonOptionsVault(params: {
         const optionState = await vault.optionState();
         const vaultState = await vault.vaultState();
 
+        assert.equal(optionState.currentOption, constants.AddressZero);
         assert.equal(optionState.nextOption, defaultOtokenAddress);
         assert.equal(
           optionState.nextOptionReadyAt,
@@ -2858,8 +2859,11 @@ function behavesLikeRibbonOptionsVault(params: {
       });
 
       it("should set the new cap", async function () {
-        await vault.connect(ownerSigner).setCap(parseEther("10"));
+        const tx = await vault.connect(ownerSigner).setCap(parseEther("10"));
         assert.equal((await vault.cap()).toString(), parseEther("10"));
+        await expect(tx)
+          .to.emit(vault, "CapSet")
+          .withArgs(parseEther("500"), parseEther("10"));
       });
 
       it("should revert when depositing over the cap", async function () {

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -955,6 +955,9 @@ function behavesLikeRibbonOptionsVault(params: {
           await expect(tx)
             .to.emit(vault, "Deposit")
             .withArgs(user, depositAmount, 1);
+          await expect(tx)
+            .to.emit(vault, "Deposit")
+            .withArgs(user, depositAmount, 1);
 
           assert.bnEqual(await vault.totalPending(), depositAmount);
           const { round, amount } = await vault.depositReceipts(user);
@@ -1378,6 +1381,7 @@ function behavesLikeRibbonOptionsVault(params: {
         const optionState = await vault.optionState();
         const vaultState = await vault.vaultState();
 
+        assert.equal(optionState.currentOption, constants.AddressZero);
         assert.equal(optionState.nextOption, defaultOtokenAddress);
         assert.equal(
           optionState.nextOptionReadyAt,
@@ -2955,8 +2959,11 @@ function behavesLikeRibbonOptionsVault(params: {
       });
 
       it("should set the new cap", async function () {
-        await vault.connect(ownerSigner).setCap(parseEther("10"));
+        const tx = await vault.connect(ownerSigner).setCap(parseEther("10"));
         assert.equal((await vault.cap()).toString(), parseEther("10"));
+        await expect(tx)
+          .to.emit(vault, "CapSet")
+          .withArgs(parseEther("500"), parseEther("10"));
       });
 
       it("should revert when depositing over the cap", async function () {

--- a/test/RibbonThetaYearnVault.ts
+++ b/test/RibbonThetaYearnVault.ts
@@ -1529,6 +1529,7 @@ function behavesLikeRibbonOptionsVault(params: {
         const optionState = await vault.optionState();
         const vaultState = await vault.vaultState();
 
+        assert.equal(optionState.currentOption, constants.AddressZero);
         assert.equal(optionState.nextOption, defaultOtokenAddress);
         assert.equal(
           optionState.nextOptionReadyAt,
@@ -3244,8 +3245,11 @@ function behavesLikeRibbonOptionsVault(params: {
       });
 
       it("should set the new cap", async function () {
-        await vault.connect(ownerSigner).setCap(parseEther("10"));
+        const tx = await vault.connect(ownerSigner).setCap(parseEther("10"));
         assert.equal((await vault.cap()).toString(), parseEther("10"));
+        await expect(tx)
+          .to.emit(vault, "CapSet")
+          .withArgs(parseEther("500"), parseEther("10"));
       });
 
       it("should revert when depositing over the cap", async function () {


### PR DESCRIPTION
GnosisAuction.sol
65: Optimization, no need to poll balance of otokens again, reuse oTokenSellAmount variable instead.

VaultLifecycle.sol
_193: Minor, using newPricePerShare to calculate queuedWithdrawAmount is not excatly correct, as the shares were queued at a variety of prices._ - isnt this a significant issue if queuedWithdrawAmount is not exactly correct. by how much?
248: Note, the mintAmount value calculation could be simplified to (depositAmount*(10^Vault.OTOKEN_DECIMALS)*(10^Vault.OTOKEN_DECIMALS)) / (oToken.strikePrice() * (10^collateralDecimals))
**254: Minor, the collateralDecimals.sub(8) expression will revert on collateral with decimals < 8. The scaleBy calculation should be put inside of the if condition.**
_257: Note, the mintAmount value for collaterals with < 8 decimals should probably be scaledUp instead of down._ - do you mean in terms of proper coding or its wrong the way it is?
263: Note, the safeApproveNonCompliant call could be replaced with CustomSafeERC20.safeApprove.
**294: Note, 'deposited asset' comment should state 'option address'.**

VaultLifecycleSTETH.sol
_158: Minor, using newPricePerShare to calculate queuedWithdrawAmount is not excatly correct, as the shares were queued at a variety of prices._ - isnt this a significant issue if queuedWithdrawAmount is not exactly correct. by how much?
**205: Note, the double approve comment is outdated. Helper is handling it all now.**
**364: Major, specifying only the minETHOut is not enough, as the amountToUnwrap could be manipulated with frontrunning. Consider requiring amountETHOut >= minETHOut instead.**

VaultLifecycleYearn.sol
_164: Minor, using newPricePerShare to calculate queuedWithdrawAmount is not excatly correct, as the shares were queued at a variety of prices._ - isnt this a significant issue if queuedWithdrawAmount is not exactly correct. by how much?
_266: Major, invalid underlyingTokensToWithdraw calculation, should use ShareMath.sharesToAsset instead._ - can you elaborate more? thought we fixed it

BaseVaults\base\RibbonVault.sol
**263: Note, the setManagementFee function should emit ManagementFeeSet event.
288: Note, the setCap function should emit CapSet event.
524: Optimization, excessive assignment of depositReceipts[msg.sender].amount if condition is not met.
552: Optimization, the overflow check is not needed as the Solidity compiler 0.8+ performs it implicitly.
596: Major, adding the queuedWithdrawAmount to the locked balance for fee calculation is not always right. Consider a case last locked was 100 and queued 10, nothing changed in the current round, so current locked is 100 and queued is 10 again, the fee will be calculated from (100+10)-100 = 10. While there was no profit.**

BaseVaults\RibbonThetaVault.sol
**384: Note, the unlockedAssedAmount variable has a typo and should be named unlockedAssetAmount.**

STETHVault\base\RibbonVault.sol
**157: the 'LDO contract' comment should be replaced with 'wstETH contract'.
284: Note, the setManagementFee function should emit ManagementFeeSet event.
307: Note, the setCap function should emit CapSet event.
548: Optimization, excessive assignment of depositReceipts[msg.sender].amount if condition is not met.
576: Optimization, the overflow check is not needed as the Solidity compiler 0.8+ performs it implicitly.
622: Major, adding the queuedWithdrawAmount to the locked balance for fee calculation is not always right. Consider a case last locked was 100 and queued 10, nothing changed in the current round, so current locked is 100 and queued is 10 again, the fee will be calculated from (100+10)-100 = 10. While there was no profit.**

STETHVault\RibbonThetaSTETHVault.sol
**402: Note, the unlockedAssedAmount variable has a typo and should be named unlockedAssetAmount.**

YearnVaults\base\RibbonVault.sol
**281: Note, the setManagementFee function should emit ManagementFeeSet event.
304: Note, the setCap function should emit CapSet event.
559: Optimization, excessive assignment of depositReceipts[msg.sender].amount if condition is not met.
588: Optimization, the overflow check is not needed as the Solidity compiler 0.8+ performs it implicitly.
628: Major, adding the queuedWithdrawAmount to the locked balance for fee calculation is not always right. Consider a case last locked was 100 and queued 10, nothing changed in the current round, so current locked is 100 and queued is 10 again, the fee will be calculated from (100+10)-100 = 10. While there was no profit.
686: Major, the upgradeYearnVault() function will not work correctly as long as asset.balance(address(this)) > 0.**
_688: Note, instead of unwrapYieldToken call, should use simple collateral.withdraw._ - we need to know how much we are to unwrap
_689: Major, asset amount is expected instead of collateral amount._ this is fixed right?

YearnVaults\RibbonThetaYearnVault.sol
**289: Minor, the commitAndClose function could be executed twice resetting the lastLockedAmount to 0. This will result in fees taken from the whole amount.
423: Note, the unlockedAssedAmount variable has a typo and should be named unlockedAssetAmount.**

- depositYieldToken
- totalBalance
- mountToUnwrap >= stethBalance