### PR TITLE
Rewrite unwrapYieldToken function

### DIFF
--- a/contracts/libraries/VaultLifecycleSTETH.sol
+++ b/contracts/libraries/VaultLifecycleSTETH.sol
@@ -388,7 +388,7 @@ library VaultLifecycleSTETH {
                 stethAvailable = steth.balanceOf(address(this));
                 require(
                     ethAvailable.add(stethAvailable) >= amount.sub(2),
-                    "Unwrapping wstETH did not result in sufficient stETH"
+                    "Unwrapping wstETH did not return sufficient stETH"
                 );
             }
         }

--- a/contracts/libraries/VaultLifecycleSTETH.sol
+++ b/contracts/libraries/VaultLifecycleSTETH.sol
@@ -354,7 +354,7 @@ library VaultLifecycleSTETH {
             "Amount withdrawn smaller than minETHOut from swap"
         );
         require(
-            minETHOut.mul(10**18).div(amount) > 0.05 ether,
+            minETHOut.mul(10**18).div(amount) >= 0.95 ether,
             "Slippage on minETHOut too high"
         );
 

--- a/contracts/libraries/VaultLifecycleSTETH.sol
+++ b/contracts/libraries/VaultLifecycleSTETH.sol
@@ -333,12 +333,12 @@ library VaultLifecycleSTETH {
 
     /**
      * @notice Unwraps the necessary amount of the wstETH token
-     *         and transfers amount to vault
+     *         and transfers `asset` amount to vault
      * @param amount is the amount of `asset` to withdraw
      * @param collateralToken is the address of the collateral token
      * @param crvPool is the address of the steth <-> eth pool on curve
      * @param minETHOut is the minimum eth amount to receive from the swap
-     * @return amountETHOut is the amount of eth we have
+     * @return amountETHOut is the amount of eth unwrapped
      available for the withdrawal (may incur curve slippage)
      */
     function unwrapYieldToken(
@@ -405,14 +405,13 @@ library VaultLifecycleSTETH {
         // CRV SWAP HERE from steth -> eth
         // 0 = ETH, 1 = STETH
         // We are setting 1, which is the smallest possible value for the _minAmountOut parameter
-        // However it is fine because we check that the amountETHOut >= minETHOut at the end
+        // However it is fine because we check that the totalETHOut >= minETHOut at the end
         // which makes sandwich attacks not possible
         uint256 ethAmountOutFromSwap =
             ICRV(crvPool).exchange(1, 0, stEthAmountToSwap, 1);
 
         uint256 totalETHOut = ethAvailable.add(ethAmountOutFromSwap);
 
-        // This revert does not account for the ETH that is already unwrapped
         // Since minETHOut is derived from calling the Curve pool's getter,
         // it reverts in the worst case where the user needs to unwrap and sell
         // 100% of their ETH withdrawal amount

--- a/contracts/libraries/VaultLifecycleSTETH.sol
+++ b/contracts/libraries/VaultLifecycleSTETH.sol
@@ -332,7 +332,7 @@ library VaultLifecycleSTETH {
     }
 
     /**
-     * @notice Unwraps the necessary amount of the yield-bearing yearn token
+     * @notice Unwraps the necessary amount of the wstETH token
      *         and transfers amount to vault
      * @param amount is the amount of `asset` to withdraw
      * @param collateralToken is the address of the collateral token
@@ -353,66 +353,76 @@ library VaultLifecycleSTETH {
             "Amount withdrawn smaller than minETHOut from swap"
         );
 
-        uint256 assetBalance = address(this).balance;
+        uint256 ethAvailable = address(this).balance;
+        IERC20 steth = IERC20(stethToken);
+        uint256 stethAvailable = steth.balanceOf(address(this));
 
-        uint256 amountETHOut = DSMath.min(assetBalance, amount);
+        // 3 different success scenarios
+        // Scenario 1. We hold enough ETH to satisfy withdrawal. Send it out directly
+        // Scenario 2. We hold enough ETH + stETH to satisfy withdrawal. Do a swap
+        // Scenario 3. We hold enough wstETH to satisy withdrawal. Unwrap then swap
 
-        // We pass in the amount of stETH we want to unwrap from wstETH
-        // Though stETH != ETH, we assume that they are equivalent here
-        // by passing in the amount of ETH we need to withdraw
-        // This assumption is fine because we will be swapping the stETH to ETH.
-        uint256 stethNeeded =
-            DSMath.max(assetBalance, amount).sub(assetBalance);
-
-        uint256 wstETHPerStETH = IWSTETH(collateralToken).tokensPerStEth();
-        uint256 amountToUnwrap = stethNeeded.mul(wstETHPerStETH).div(10**18);
-
-        if (amountToUnwrap > 0) {
-            IWSTETH wsteth = IWSTETH(collateralToken);
-            IERC20 steth = IERC20(stethToken);
-
-            uint256 startStethBalance = steth.balanceOf(address(this));
-
-            if (stethNeeded > startStethBalance) {
-                amountToUnwrap = stethNeeded
-                    .sub(startStethBalance)
-                    .mul(wstETHPerStETH)
-                    .div(10**18);
-                // Unwrap to stETH
-                wsteth.unwrap(amountToUnwrap);
-            }
-
-            // Post-unwrap, the stETH balance will not completely match the stethNeeded
-            // due to precision issues.
-            // E.g. 0.5 ETH is 499999999999999998 instead of 500000000000000000
-            // We just send the entire stETH balance for the swap
-            uint256 stETHAmount =
-                steth.balanceOf(address(this)).sub(startStethBalance);
-
-            // approve steth exchange
-            steth.safeApprove(crvPool, stETHAmount);
-
-            // CRV SWAP HERE from steth -> eth
-            // 0 = ETH, 1 = STETH
-            // We are setting 1, which is the smallest possible value for the _minAmountOut parameter
-            // However it is fine because we check that the amountETHOut >= minETHOut at the end
-            // which makes sandwich attacks not possible
-            uint256 swappedAmount =
-                ICRV(crvPool).exchange(1, 0, stETHAmount, 1);
-
-            amountETHOut = amountETHOut.add(swappedAmount);
+        // Scenario 1
+        if (ethAvailable >= amount) {
+            return amount;
         }
+
+        // We unwrap if necessary first, then do the swap
+        uint256 ethstEthSum = ethAvailable.add(stethAvailable);
+        bool hasEnoughETHForWithdrawal = ethstEthSum >= amount.sub(1);
+
+        // Scenario 3
+        {
+            if (!hasEnoughETHForWithdrawal) {
+                uint256 stethNeededFromUnwrap = amount.sub(ethstEthSum);
+                uint256 wstAmountToUnwrap =
+                    IWSTETH(collateralToken).getWstETHByStETH(
+                        stethNeededFromUnwrap
+                    );
+
+                // We unwrap an additional wei because the unwrap process is off by 1
+                IWSTETH(collateralToken).unwrap(wstAmountToUnwrap);
+
+                // We do a final double check that we have enough to satisfy the amount
+                // We account for the off by 1 error
+                stethAvailable = steth.balanceOf(address(this));
+                require(
+                    ethAvailable.add(stethAvailable) >= amount.sub(2),
+                    "Unwrapping wstETH did not result in sufficient stETH"
+                );
+            }
+        }
+
+        // Scenario 2
+        // Now that we satisfied the ETH + stETH sum, we swap the stETH amounts necessary
+        // to facilitate a withdrawal
+
+        // This won't underflow since we already asserted that ethAvailable < amount before this
+        uint256 stEthAmountToSwap =
+            DSMath.min(amount.sub(ethAvailable), stethAvailable);
+
+        steth.safeApprove(crvPool, stEthAmountToSwap);
+
+        // CRV SWAP HERE from steth -> eth
+        // 0 = ETH, 1 = STETH
+        // We are setting 1, which is the smallest possible value for the _minAmountOut parameter
+        // However it is fine because we check that the amountETHOut >= minETHOut at the end
+        // which makes sandwich attacks not possible
+        uint256 ethAmountOutFromSwap =
+            ICRV(crvPool).exchange(1, 0, stEthAmountToSwap, 1);
+
+        uint256 totalETHOut = ethAvailable.add(ethAmountOutFromSwap);
 
         // This revert does not account for the ETH that is already unwrapped
         // Since minETHOut is derived from calling the Curve pool's getter,
         // it reverts in the worst case where the user needs to unwrap and sell
         // 100% of their ETH withdrawal amount
         require(
-            amountETHOut >= minETHOut,
+            totalETHOut >= minETHOut,
             "Output ETH amount smaller than minETHOut"
         );
 
-        return amountETHOut;
+        return totalETHOut;
     }
 
     /**

--- a/contracts/libraries/VaultLifecycleSTETH.sol
+++ b/contracts/libraries/VaultLifecycleSTETH.sol
@@ -369,7 +369,7 @@ library VaultLifecycleSTETH {
 
         // We unwrap if necessary first, then do the swap
         uint256 ethstEthSum = ethAvailable.add(stethAvailable);
-        bool hasEnoughETHForWithdrawal = ethstEthSum >= amount.sub(1);
+        bool hasEnoughETHForWithdrawal = ethstEthSum >= amount.sub(1); // off by 1
 
         // Scenario 3
         {
@@ -380,7 +380,6 @@ library VaultLifecycleSTETH {
                         stethNeededFromUnwrap
                     );
 
-                // We unwrap an additional wei because the unwrap process is off by 1
                 IWSTETH(collateralToken).unwrap(wstAmountToUnwrap);
 
                 // We do a final double check that we have enough to satisfy the amount

--- a/test/RibbonThetaSTETHVault.ts
+++ b/test/RibbonThetaSTETHVault.ts
@@ -80,7 +80,7 @@ describe("RibbonThetaSTETHVault", () => {
     premiumDiscount: BigNumber.from("997"),
     managementFee: BigNumber.from("2000000"),
     performanceFee: BigNumber.from("20000000"),
-    crvSlippage: BigNumber.from("10"),
+    crvSlippage: BigNumber.from("1"),
     crvETHAmountAfterSlippage: BigNumber.from("998258752506440113"),
     auctionDuration: 21600,
     tokenDecimals: 18,
@@ -2447,6 +2447,25 @@ function behavesLikeRibbonOptionsVault(params: {
         assert.bnEqual(amount, BigNumber.from(0));
         // Should decrement the pending amounts
         assert.bnEqual(await vault.totalPending(), BigNumber.from(0));
+      });
+
+      it("is able to withdraw the deposited stETH instantly", async () => {
+        const steth = await ethers.getContractAt(
+          "ISTETH",
+          intermediaryAsset,
+          userSigner
+        );
+
+        await steth.submit(user, { value: depositAmount });
+
+        await steth.approve(vault.address, depositAmount);
+
+        await vault.depositYieldToken(depositAmount);
+
+        await vault.withdrawInstantly(
+          depositAmount.sub(1),
+          depositAmount.mul(BigNumber.from(100).sub(crvSlippage)).div(100)
+        );
       });
     });
 

--- a/test/RibbonThetaSTETHVault.ts
+++ b/test/RibbonThetaSTETHVault.ts
@@ -81,7 +81,7 @@ describe("RibbonThetaSTETHVault", () => {
     managementFee: BigNumber.from("2000000"),
     performanceFee: BigNumber.from("20000000"),
     crvSlippage: BigNumber.from("10"),
-    crvETHAmountAfterSlippage: BigNumber.from("998258752506440112"),
+    crvETHAmountAfterSlippage: BigNumber.from("998258752506440113"),
     auctionDuration: 21600,
     tokenDecimals: 18,
     isPut: false,

--- a/test/libraries/VaultLifecycleSTETH.ts
+++ b/test/libraries/VaultLifecycleSTETH.ts
@@ -65,7 +65,39 @@ describe("VaultLifecycleSTETH", () => {
       ).to.be.revertedWith("Amount withdrawn smaller than minETHOut from swap");
     });
 
-    it("performs a swap when balance is less than withdraw amount", async () => {
+    it("performs a swap when there is existing ETH + stETH balance", async () => {
+      // only 0.5 on contract so we need to swap 0.5
+      await signer.sendTransaction({
+        to: lifecycle.address,
+        value: parseEther("0.5"),
+      });
+
+      await stETH.submit(signer.address, { value: parseEther("0.5") });
+
+      await stETH.transfer(lifecycle.address, parseEther("0.5"));
+
+      await lifecycle.unwrapYieldToken(
+        parseEther("1"),
+        parseEther("0.995") // 0.5% slippage
+      );
+
+      assert.bnGte(await lifecycle.output(), parseEther("0.995"));
+    });
+
+    it("performs a swap when there is existing stETH balance", async () => {
+      await stETH.submit(signer.address, { value: parseEther("1") });
+
+      await stETH.transfer(lifecycle.address, parseEther("1"));
+
+      await lifecycle.unwrapYieldToken(
+        parseEther("1"),
+        parseEther("0.995") // 0.5% slippage
+      );
+
+      assert.bnGte(await lifecycle.output(), parseEther("0.995"));
+    });
+
+    it("performs a swap when there is existing ETH + wstETH balance", async () => {
       // only 0.5 on contract so we need to swap 0.5
       await signer.sendTransaction({
         to: lifecycle.address,
@@ -89,6 +121,52 @@ describe("VaultLifecycleSTETH", () => {
       );
 
       assert.bnGte(await lifecycle.output(), parseEther("0.995"));
+    });
+
+    it("performs a swap when there is existing wstETH balance", async () => {
+      await stETH.submit(signer.address, { value: parseEther("1") });
+
+      await stETH.approve(wstETH.address, parseEther("1"));
+
+      await wstETH.wrap(parseEther("1"));
+
+      await wstETH.transfer(
+        lifecycle.address,
+        await wstETH.balanceOf(signer.address)
+      );
+
+      await lifecycle.unwrapYieldToken(
+        parseEther("1"),
+        parseEther("0.995") // 0.5% slippage
+      );
+
+      assert.bnGte(await lifecycle.output(), parseEther("0.995"));
+    });
+
+    it("reverts when slippage is too low", async () => {
+      await stETH.submit(signer.address, { value: parseEther("1") });
+
+      await stETH.approve(wstETH.address, parseEther("1"));
+
+      await wstETH.wrap(parseEther("1"));
+
+      await wstETH.transfer(
+        lifecycle.address,
+        await wstETH.balanceOf(signer.address)
+      );
+
+      await expect(
+        lifecycle.unwrapYieldToken(
+          parseEther("1"),
+          parseEther("0.999") // 0.5% slippage
+        )
+      ).to.be.revertedWith("Output ETH amount smaller than minETHOut");
+    });
+
+    it("reverts when minETHOut is larger than amount", async () => {
+      await expect(
+        lifecycle.unwrapYieldToken(parseEther("1"), parseEther("1.001"))
+      ).to.be.revertedWith("Amount withdrawn smaller than minETHOut from swap");
     });
   });
 });

--- a/test/libraries/VaultLifecycleSTETH.ts
+++ b/test/libraries/VaultLifecycleSTETH.ts
@@ -171,8 +171,8 @@ describe("VaultLifecycleSTETH", () => {
 
     it("reverts when minETHOut is <0.95 of the amount", async () => {
       await expect(
-        lifecycle.unwrapYieldToken(parseEther("1"), parseEther("1.051"))
-      ).to.be.revertedWith("Amount withdrawn smaller than minETHOut from swap");
+        lifecycle.unwrapYieldToken(parseEther("1"), parseEther("0.949"))
+      ).to.be.revertedWith("Slippage on minETHOut too high");
     });
   });
 });

--- a/test/libraries/VaultLifecycleSTETH.ts
+++ b/test/libraries/VaultLifecycleSTETH.ts
@@ -168,5 +168,11 @@ describe("VaultLifecycleSTETH", () => {
         lifecycle.unwrapYieldToken(parseEther("1"), parseEther("1.001"))
       ).to.be.revertedWith("Amount withdrawn smaller than minETHOut from swap");
     });
+
+    it("reverts when minETHOut is <0.95 of the amount", async () => {
+      await expect(
+        lifecycle.unwrapYieldToken(parseEther("1"), parseEther("1.051"))
+      ).to.be.revertedWith("Amount withdrawn smaller than minETHOut from swap");
+    });
   });
 });


### PR DESCRIPTION
The `unwrapYieldToken` function did not account for the scenario where we are 100% in stETH. This PR fixes it