### PR TITLE
Move UniswapRouter to be a part of VaultLifecycle to simplify deployment

### DIFF
--- a/contracts/libraries/UniswapRouter.sol
+++ b/contracts/libraries/UniswapRouter.sol
@@ -28,7 +28,7 @@ library UniswapRouter {
         address validTokenIn,
         address validTokenOut,
         address uniswapFactory
-    ) public view returns (bool isValidPath) {
+    ) internal view returns (bool isValidPath) {
         // Function checks if the tokenIn and tokenOut in the swapPath
         // matches the validTokenIn and validTokenOut specified.
         address tokenIn;

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -717,6 +717,21 @@ library VaultLifecycle {
         }
     }
 
+    function checkPath(
+        bytes calldata swapPath,
+        address validTokenIn,
+        address validTokenOut,
+        address uniswapFactory
+    ) external view returns (bool isValidPath) {
+        return
+            UniswapRouter.checkPath(
+                swapPath,
+                validTokenIn,
+                validTokenOut,
+                uniswapFactory
+            );
+    }
+
     /**
      * @notice Places a bid in an auction
      * @param bidDetails is the struct with all the details of the

--- a/contracts/vaults/BaseVaults/RibbonThetaVault.sol
+++ b/contracts/vaults/BaseVaults/RibbonThetaVault.sol
@@ -15,7 +15,6 @@ import {Vault} from "../../libraries/Vault.sol";
 import {VaultLifecycle} from "../../libraries/VaultLifecycle.sol";
 import {ShareMath} from "../../libraries/ShareMath.sol";
 import {RibbonVault} from "./base/RibbonVault.sol";
-import {UniswapRouter} from "../../libraries/UniswapRouter.sol";
 
 /**
  * UPGRADEABILITY: Since we use the upgradeable proxy pattern, we must observe
@@ -191,7 +190,7 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
 
         isUsdcAuction = _initParams._isUsdcAuction;
         if (_initParams._isUsdcAuction) {
-            require(_checkPath(_initParams._swapPath), "");
+            require(_checkPath(_initParams._swapPath), "Invalid swapPath");
             swapPath = _initParams._swapPath;
         }
     }
@@ -279,7 +278,7 @@ contract RibbonThetaVault is RibbonVault, RibbonThetaVaultStorage {
         nonReentrant
     {
         require(isUsdcAuction, "!isUsdcAuction");
-        require(_checkPath(newSwapPath), "Invalid swap path");
+        require(_checkPath(newSwapPath), "Invalid swapPath");
         swapPath = newSwapPath;
     }
 

--- a/contracts/vaults/BaseVaults/base/RibbonVault.sol
+++ b/contracts/vaults/BaseVaults/base/RibbonVault.sol
@@ -19,7 +19,6 @@ import {
 import {Vault} from "../../../libraries/Vault.sol";
 import {VaultLifecycle} from "../../../libraries/VaultLifecycle.sol";
 import {ShareMath} from "../../../libraries/ShareMath.sol";
-import {UniswapRouter} from "../../../libraries/UniswapRouter.sol";
 import {IWETH} from "../../../interfaces/IWETH.sol";
 
 contract RibbonVault is
@@ -792,7 +791,7 @@ contract RibbonVault is
      */
     function _checkPath(bytes calldata swapPath) internal view returns (bool) {
         return
-            UniswapRouter.checkPath(
+            VaultLifecycle.checkPath(
                 swapPath,
                 USDC,
                 vaultParams.asset,

--- a/scripts/deploy/01_theta_vault_logic.ts
+++ b/scripts/deploy/01_theta_vault_logic.ts
@@ -26,12 +26,6 @@ const main = async ({
     from: deployer,
   });
 
-  // Supports Uniswap V3 only
-  const dexRouter = await deploy("UniswapRouter", {
-    contract: "UniswapRouter",
-    from: deployer,
-  });
-
   const vault = await deploy("RibbonThetaVaultLogic", {
     contract: "RibbonThetaVault",
     from: deployer,
@@ -43,11 +37,10 @@ const main = async ({
       MARGIN_POOL[chainId],
       GNOSIS_EASY_AUCTION[chainId],
       DEX_ROUTER[chainId],
-      DEX_FACTORY[chainId]
+      DEX_FACTORY[chainId],
     ],
     libraries: {
       VaultLifecycle: lifecycle.address,
-      UniswapRouter: dexRouter.address, // Supports only Uniswap v3
     },
   });
   console.log(`RibbonThetaVaultLogic @ ${vault.address}`);

--- a/scripts/deploy/02_eth_call_theta_vault.ts
+++ b/scripts/deploy/02_eth_call_theta_vault.ts
@@ -58,16 +58,9 @@ const main = async ({
   const logicDeployment = await deployments.get("RibbonThetaVaultLogic");
   const lifecycle = await deployments.get("VaultLifecycle");
 
-  // Supports Uniswap V3 only
-  const dexRouter = await deploy("UniswapRouter", {
-    contract: "UniswapRouter",
-    from: deployer,
-  });
-
   const RibbonThetaVault = await ethers.getContractFactory("RibbonThetaVault", {
     libraries: {
       VaultLifecycle: lifecycle.address,
-      UniswapRouter: dexRouter.address, // Supports only Uniswap v3
     },
   });
 

--- a/scripts/deploy/03_wbtc_call_theta_vault.ts
+++ b/scripts/deploy/03_wbtc_call_theta_vault.ts
@@ -58,16 +58,9 @@ const main = async ({
   const logicDeployment = await deployments.get("RibbonThetaVaultLogic");
   const lifecycle = await deployments.get("VaultLifecycle");
 
-  // Supports Uniswap V3 only
-  const dexRouter = await deploy("UniswapRouter", {
-    contract: "UniswapRouter",
-    from: deployer,
-  });
-
   const RibbonThetaVault = await ethers.getContractFactory("RibbonThetaVault", {
     libraries: {
       VaultLifecycle: lifecycle.address,
-      UniswapRouter: dexRouter.address, // Supports only Uniswap v3
     },
   });
 

--- a/scripts/deploy/06_aave_call_theta_vault.ts
+++ b/scripts/deploy/06_aave_call_theta_vault.ts
@@ -28,14 +28,17 @@ const main = async ({
   const chainId = network.config.chainId;
 
   if (chainId === CHAINID.AVAX_MAINNET || chainId === CHAINID.AVAX_FUJI) {
-    console.log(`06 - Skipping deployment AAVE Call Theta Vault on ${network.name}`);
+    console.log(
+      `06 - Skipping deployment AAVE Call Theta Vault on ${network.name}`
+    );
     return;
   }
 
   const { BigNumber } = ethers;
   const { parseEther } = ethers.utils;
   const { deploy } = deployments;
-  const { deployer, owner, keeper, admin, feeRecipient } = await getNamedAccounts();
+  const { deployer, owner, keeper, admin, feeRecipient } =
+    await getNamedAccounts();
   console.log(`06 - Deploying AAVE Call Theta Vault on ${network.name}`);
 
   const isMainnet = network.name === "mainnet";
@@ -67,16 +70,9 @@ const main = async ({
   const logicDeployment = await deployments.get("RibbonThetaVaultLogic");
   const lifecycle = await deployments.get("VaultLifecycle");
 
-  // Supports Uniswap V3 only
-  const dexRouter = await deploy("UniswapRouter", {
-    contract: "UniswapRouter",
-    from: deployer,
-  });
-
   const RibbonThetaVault = await ethers.getContractFactory("RibbonThetaVault", {
     libraries: {
       VaultLifecycle: lifecycle.address,
-      // UniswapRouter: dexRouter.address, // Supports only Uniswap v3
     },
   });
 

--- a/test/RibbonDeltaVault.ts
+++ b/test/RibbonDeltaVault.ts
@@ -284,7 +284,6 @@ function behavesLikeRibbonOptionsVault(params: {
   let optionsPremiumPricer: Contract;
   let gnosisAuction: Contract;
   let vaultLifecycleLib: Contract;
-  let uniswapRouterLib: Contract;
   let thetaVault: Contract;
   let vault: Contract;
   let oTokenFactory: Contract;
@@ -420,9 +419,6 @@ function behavesLikeRibbonOptionsVault(params: {
       const VaultLifecycle = await ethers.getContractFactory("VaultLifecycle");
       vaultLifecycleLib = await VaultLifecycle.deploy();
 
-      const uniswapRouter = await ethers.getContractFactory("UniswapRouter");
-      uniswapRouterLib = await uniswapRouter.deploy();
-
       gnosisAuction = await getContractAt(
         "IGnosisAuction",
         GNOSIS_EASY_AUCTION[chainId]
@@ -474,7 +470,6 @@ function behavesLikeRibbonOptionsVault(params: {
           {
             libraries: {
               VaultLifecycle: vaultLifecycleLib.address,
-              UniswapRouter: uniswapRouterLib.address,
             },
           }
         )

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -2655,7 +2655,7 @@ function behavesLikeRibbonOptionsVault(params: {
         const tx = await vault.connect(keeperSigner).rollToNextOption();
         const receipt = await tx.wait();
 
-        assert.isAtMost(receipt.gasUsed.toNumber(), 966159); //963542, 1082712
+        assert.isAtMost(receipt.gasUsed.toNumber(), 96700); //963542, 1082712
         // console.log("rollToNextOption", receipt.gasUsed.toNumber());
       });
     });

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -341,7 +341,6 @@ function behavesLikeRibbonOptionsVault(params: {
   let volOracle: Contract;
   let optionsPremiumPricer: Contract;
   let gnosisAuction: Contract;
-  let dexRouterLib: Contract;
   let dexFactory: Contract;
   let vaultLifecycleLib: Contract;
   let vault: Contract;
@@ -465,9 +464,6 @@ function behavesLikeRibbonOptionsVault(params: {
         params.deltaStep
       );
 
-      const dexRouter = await ethers.getContractFactory("UniswapRouter"); // Supports Uniswap V3 only
-      dexRouterLib = await dexRouter.deploy();
-
       const VaultLifecycle = await ethers.getContractFactory("VaultLifecycle");
       vaultLifecycleLib = await VaultLifecycle.deploy();
 
@@ -522,7 +518,6 @@ function behavesLikeRibbonOptionsVault(params: {
           {
             libraries: {
               VaultLifecycle: vaultLifecycleLib.address,
-              UniswapRouter: dexRouterLib.address, // Supports UniswapV3 only
             },
           }
         )
@@ -665,7 +660,6 @@ function behavesLikeRibbonOptionsVault(params: {
           {
             libraries: {
               VaultLifecycle: vaultLifecycleLib.address,
-              UniswapRouter: dexRouterLib.address, // Supports only Uniswap v3
             },
           }
         );

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -2655,7 +2655,7 @@ function behavesLikeRibbonOptionsVault(params: {
         const tx = await vault.connect(keeperSigner).rollToNextOption();
         const receipt = await tx.wait();
 
-        assert.isAtMost(receipt.gasUsed.toNumber(), 96700); //963542, 1082712
+        assert.isAtMost(receipt.gasUsed.toNumber(), 967000); //963542, 1082712
         // console.log("rollToNextOption", receipt.gasUsed.toNumber());
       });
     });

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -1152,7 +1152,7 @@ function behavesLikeRibbonOptionsVault(params: {
             vault
               .connect(ownerSigner)
               .setSwapPath(encodePath([WETH_ADDRESS[chainId], asset], [10000]))
-          ).to.be.revertedWith("Invalid swap path");
+          ).to.be.revertedWith("Invalid swapPath");
         });
 
         it("reverts when tokenOut is not underlying", async function () {
@@ -1165,7 +1165,7 @@ function behavesLikeRibbonOptionsVault(params: {
                   [10000]
                 )
               )
-          ).to.be.revertedWith("Invalid swap path");
+          ).to.be.revertedWith("Invalid swapPath");
         });
 
         it("reverts when not owner call", async function () {
@@ -1207,7 +1207,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
           const receipt = await tx.wait();
           // ~58692 if checkPath is made into internal function
-          assert.isAtMost(receipt.gasUsed.toNumber(), 64860);
+          assert.isAtMost(receipt.gasUsed.toNumber(), 65000);
         });
       } else {
         it("reverts when isUsdcAuction is false", async function () {


### PR DESCRIPTION
- Remove UniswapRouter as a dependency for RibbonThetaVault
- It was duplicated across a standalone deployment and part of VaultLifecycle so this should save gas on deployments