### PR TITLE
[WIP] Hardhat fork caching to speed up CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./cache/hardhat-network-fork
-          key: ${{ runner.OS }}-hardhat-${{ hashFiles('./cache/hardhat-network-fork/**') }}
+          # we use the constants.ts file as a cache-key because it holds the block height we are forking
+          key: ${{ runner.OS }}-hardhat-${{ hashFiles('./constants/constants.ts') }}
           restore-keys: |
             ${{ runner.OS }}-hardhat-
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,14 @@ jobs:
           key: ${{ runner.OS }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.OS }}-yarn-
+      - name: Cache Hardhat forks
+        id: hardhat-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        uses: actions/cache@v2
+        with:
+          path: ./cache/hardhat-network-fork
+          key: ${{ runner.OS }}-hardhat
+          restore-keys: |
+            ${{ runner.OS }}-hardhat
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Compile Solidity contracts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./cache/hardhat-network-fork
-          key: ${{ runner.OS }}-hardhat
+          key: ${{ runner.OS }}-hardhat-${{ hashFiles('./cache/hardhat-network-fork/**') }}
           restore-keys: |
-            ${{ runner.OS }}-hardhat
+            ${{ runner.OS }}-hardhat-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Compile Solidity contracts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,10 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-yarn-
       - name: Cache Hardhat forks
-        id: hardhat-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        id: hardhat-cache # use this to check for `cache-hit` (`steps.hardhat-cache.outputs.cache-hit != 'true'`)
         uses: actions/cache@v2
         with:
-          path: ./cache/hardhat-network-fork
+          path: cache/hardhat-network-fork
           # we use the constants.ts file as a cache-key because it holds the block height we are forking
           key: ${{ runner.OS }}-hardhat-${{ hashFiles('./constants/constants.ts') }}
           restore-keys: |

--- a/test/RibbonDeltaVault.ts
+++ b/test/RibbonDeltaVault.ts
@@ -360,7 +360,7 @@ function behavesLikeRibbonOptionsVault(params: {
     };
 
     before(async function () {
-      await forkBlock(BLOCK_NUMBER);
+      await forkBlock(BLOCK_NUMBER[chainId]);
 
       initSnapshotId = await time.takeSnapshot();
 

--- a/test/RibbonDeltaVault.ts
+++ b/test/RibbonDeltaVault.ts
@@ -22,6 +22,7 @@ import {
   DEX_ROUTER,
   OptionsPremiumPricer_BYTECODE,
   TestVolOracle_BYTECODE,
+  BLOCK_NUMBER,
 } from "../constants/constants";
 import {
   deployProxy,
@@ -34,6 +35,7 @@ import {
 } from "./helpers/utils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import { assert } from "./helpers/assertions";
+import { forkBlock } from "./helpers/forking";
 
 const { provider, getContractAt, getContractFactory } = ethers;
 const { parseEther } = ethers.utils;
@@ -358,18 +360,7 @@ function behavesLikeRibbonOptionsVault(params: {
     };
 
     before(async function () {
-      // Reset block
-      await network.provider.request({
-        method: "hardhat_reset",
-        params: [
-          {
-            forking: {
-              jsonRpcUrl: process.env.TEST_URI,
-              blockNumber: 12529250,
-            },
-          },
-        ],
-      });
+      await forkBlock(BLOCK_NUMBER);
 
       initSnapshotId = await time.takeSnapshot();
 

--- a/test/RibbonThetaSTETHVault.ts
+++ b/test/RibbonThetaSTETHVault.ts
@@ -21,6 +21,7 @@ import {
   WSTETH_PRICER,
   OptionsPremiumPricer_BYTECODE,
   TestVolOracle_BYTECODE,
+  BLOCK_NUMBER_NEW,
 } from "../constants/constants";
 import {
   deployProxy,
@@ -37,6 +38,7 @@ import {
 import { wmul } from "./helpers/math";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import { assert } from "./helpers/assertions";
+import { forkBlock } from "./helpers/forking";
 
 const { provider, getContractAt, getContractFactory } = ethers;
 const { parseEther } = ethers.utils;
@@ -264,18 +266,7 @@ function behavesLikeRibbonOptionsVault(params: {
     };
 
     before(async function () {
-      // Reset block
-      await network.provider.request({
-        method: "hardhat_reset",
-        params: [
-          {
-            forking: {
-              jsonRpcUrl: process.env.TEST_URI,
-              blockNumber: 13056027,
-            },
-          },
-        ],
-      });
+      await forkBlock(BLOCK_NUMBER_NEW[chainId]);
 
       initSnapshotId = await time.takeSnapshot();
 

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -48,6 +48,7 @@ import { wmul, wdiv } from "./helpers/math";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import { assert } from "./helpers/assertions";
 import { TEST_URI } from "../scripts/helpers/getDefaultEthersProvider";
+import { forkBlock } from "./helpers/forking";
 const { provider, getContractAt, getContractFactory } = ethers;
 const { parseEther } = ethers.utils;
 
@@ -403,18 +404,7 @@ function behavesLikeRibbonOptionsVault(params: {
     };
 
     before(async function () {
-      // Reset block
-      await network.provider.request({
-        method: "hardhat_reset",
-        params: [
-          {
-            forking: {
-              jsonRpcUrl: TEST_URI[chainId],
-              blockNumber: BLOCK_NUMBER_NEW[chainId],
-            },
-          },
-        ],
-      });
+      await forkBlock(BLOCK_NUMBER_NEW[chainId]);
 
       initSnapshotId = await time.takeSnapshot();
 

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -47,7 +47,6 @@ import {
 import { wmul, wdiv } from "./helpers/math";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import { assert } from "./helpers/assertions";
-import { TEST_URI } from "../scripts/helpers/getDefaultEthersProvider";
 import { forkBlock } from "./helpers/forking";
 const { provider, getContractAt, getContractFactory } = ethers;
 const { parseEther } = ethers.utils;

--- a/test/RibbonThetaYearnVault.ts
+++ b/test/RibbonThetaYearnVault.ts
@@ -22,6 +22,7 @@ import {
   YEARN_REGISTRY_ADDRESS,
   OptionsPremiumPricer_BYTECODE,
   TestVolOracle_BYTECODE,
+  BLOCK_NUMBER_NEW,
 } from "../constants/constants";
 import {
   deployProxy,

--- a/test/RibbonThetaYearnVault.ts
+++ b/test/RibbonThetaYearnVault.ts
@@ -38,6 +38,7 @@ import {
 import { wmul, wdiv } from "./helpers/math";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import { assert } from "./helpers/assertions";
+import { forkBlock } from "./helpers/forking";
 
 const { provider, getContractAt, getContractFactory } = ethers;
 const { parseEther } = ethers.utils;
@@ -282,21 +283,7 @@ function behavesLikeRibbonOptionsVault(params: {
     };
 
     before(async function () {
-      // Reset block
-      await network.provider.request({
-        method: "hardhat_reset",
-        params: [
-          {
-            forking: {
-              jsonRpcUrl: process.env.TEST_URI,
-              blockNumber:
-                params.depositAsset === WETH_ADDRESS[chainId]
-                  ? 12474917
-                  : 12655142,
-            },
-          },
-        ],
-      });
+      await forkBlock(BLOCK_NUMBER_NEW[chainId]);
 
       initSnapshotId = await time.takeSnapshot();
 

--- a/test/RibbonTreasuryVault.ts
+++ b/test/RibbonTreasuryVault.ts
@@ -40,7 +40,6 @@ import {
 import { wmul } from "./helpers/math";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import { assert } from "./helpers/assertions";
-import { TEST_URI } from "../scripts/helpers/getDefaultEthersProvider";
 import { forkBlock } from "./helpers/forking";
 const { provider, getContractAt, getContractFactory } = ethers;
 const { parseEther } = ethers.utils;

--- a/test/RibbonTreasuryVault.ts
+++ b/test/RibbonTreasuryVault.ts
@@ -41,6 +41,7 @@ import { wmul } from "./helpers/math";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import { assert } from "./helpers/assertions";
 import { TEST_URI } from "../scripts/helpers/getDefaultEthersProvider";
+import { forkBlock } from "./helpers/forking";
 const { provider, getContractAt, getContractFactory } = ethers;
 const { parseEther } = ethers.utils;
 
@@ -327,18 +328,7 @@ function behavesLikeRibbonOptionsVault(params: {
     };
 
     before(async function () {
-      // Reset block
-      await network.provider.request({
-        method: "hardhat_reset",
-        params: [
-          {
-            forking: {
-              jsonRpcUrl: TEST_URI[chainId],
-              blockNumber: BLOCK_NUMBER_NEW[chainId],
-            },
-          },
-        ],
-      });
+      await forkBlock(BLOCK_NUMBER_NEW[chainId]);
 
       initSnapshotId = await time.takeSnapshot();
 

--- a/test/StrikeSelectionE2E-ManualVolOracle.ts
+++ b/test/StrikeSelectionE2E-ManualVolOracle.ts
@@ -30,7 +30,8 @@ describe("StrikeSelectionE2E-ManualVolOracle", () => {
   const usdcPriceOracleAddress = "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6";
 
   before(async function () {
-    await forkBlock(BLOCK_NUMBER);
+    const chainId = network.config.chainId;
+    await forkBlock(BLOCK_NUMBER[chainId]);
 
     [(signer, signer2)] = await ethers.getSigners();
     const ManualVolOracle = await getContractFactory(

--- a/test/StrikeSelectionE2E-ManualVolOracle.ts
+++ b/test/StrikeSelectionE2E-ManualVolOracle.ts
@@ -33,7 +33,8 @@ describe("StrikeSelectionE2E-ManualVolOracle", () => {
     const chainId = network.config.chainId;
     await forkBlock(BLOCK_NUMBER[chainId]);
 
-    [(signer, signer2)] = await ethers.getSigners();
+    [signer, signer2] = await ethers.getSigners();
+
     const ManualVolOracle = await getContractFactory(
       ManualVolOracle_ABI,
       ManualVolOracle_BYTECODE,

--- a/test/StrikeSelectionE2E-ManualVolOracle.ts
+++ b/test/StrikeSelectionE2E-ManualVolOracle.ts
@@ -9,7 +9,9 @@ import ManualVolOracle_ABI from "../constants/abis/ManualVolOracle.json";
 import {
   OptionsPremiumPricer_BYTECODE,
   ManualVolOracle_BYTECODE,
+  BLOCK_NUMBER,
 } from "../constants/constants";
+import { forkBlock } from "./helpers/forking";
 const { getContractFactory } = ethers;
 
 describe("StrikeSelectionE2E-ManualVolOracle", () => {
@@ -28,20 +30,9 @@ describe("StrikeSelectionE2E-ManualVolOracle", () => {
   const usdcPriceOracleAddress = "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6";
 
   before(async function () {
-    // Reset block
-    await network.provider.request({
-      method: "hardhat_reset",
-      params: [
-        {
-          forking: {
-            jsonRpcUrl: process.env.TEST_URI,
-            blockNumber: 12529250,
-          },
-        },
-      ],
-    });
+    await forkBlock(BLOCK_NUMBER);
 
-    [signer, signer2] = await ethers.getSigners();
+    [(signer, signer2)] = await ethers.getSigners();
     const ManualVolOracle = await getContractFactory(
       ManualVolOracle_ABI,
       ManualVolOracle_BYTECODE,

--- a/test/StrikeSelectionE2E.ts
+++ b/test/StrikeSelectionE2E.ts
@@ -8,9 +8,11 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import OptionsPremiumPricer_ABI from "../constants/abis/OptionsPremiumPricer.json";
 import TestVolOracle_ABI from "../constants/abis/TestVolOracle.json";
 import {
+  BLOCK_NUMBER,
   OptionsPremiumPricer_BYTECODE,
   TestVolOracle_BYTECODE,
 } from "../constants/constants";
+import { forkBlock } from "./helpers/forking";
 const { provider, getContractFactory } = ethers;
 
 moment.tz.setDefault("UTC");
@@ -32,18 +34,7 @@ describe("StrikeSelectionE2E", () => {
   const usdcPriceOracleAddress = "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6";
 
   before(async function () {
-    // Reset block
-    await network.provider.request({
-      method: "hardhat_reset",
-      params: [
-        {
-          forking: {
-            jsonRpcUrl: process.env.TEST_URI,
-            blockNumber: 12529250,
-          },
-        },
-      ],
-    });
+    await forkBlock(BLOCK_NUMBER)
 
     [signer, signer2] = await ethers.getSigners();
     const TestVolOracle = await getContractFactory(

--- a/test/StrikeSelectionE2E.ts
+++ b/test/StrikeSelectionE2E.ts
@@ -34,7 +34,8 @@ describe("StrikeSelectionE2E", () => {
   const usdcPriceOracleAddress = "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6";
 
   before(async function () {
-    await forkBlock(BLOCK_NUMBER)
+    const chainId = network.config.chainId;
+    await forkBlock(BLOCK_NUMBER[chainId]);
 
     [signer, signer2] = await ethers.getSigners();
     const TestVolOracle = await getContractFactory(

--- a/test/helpers/forking.ts
+++ b/test/helpers/forking.ts
@@ -1,0 +1,21 @@
+import { network, ethers } from "hardhat";
+
+export const forkBlock = async (blockNumber: number) => {
+  const currentBlockNumber = await ethers.provider.getBlockNumber();
+  // If it is the same block, we avoid forking
+  if (currentBlockNumber === blockNumber) {
+    return;
+  }
+
+  await network.provider.request({
+    method: "hardhat_reset",
+    params: [
+      {
+        forking: {
+          jsonRpcUrl: process.env.TEST_URI,
+          blockNumber,
+        },
+      },
+    ],
+  });
+};

--- a/test/upgrades/RibbonThetaVault.ts
+++ b/test/upgrades/RibbonThetaVault.ts
@@ -13,6 +13,7 @@ import {
 import { parseLog } from "../helpers/utils";
 import deployments from "../../constants/deployments.json";
 import { BigNumber, BigNumberish } from "ethers";
+import { forkBlock } from "../helpers/forking";
 
 const { parseEther } = ethers.utils;
 
@@ -31,19 +32,7 @@ describe("RibbonThetaVault upgrade", () => {
   let vaults: string[] = [];
 
   before(async function () {
-    // We need to checkpoint the contract on mainnet to a past block before the upgrade happens
-    // This means the `implementation` is pointing to an old contract
-    await network.provider.request({
-      method: "hardhat_reset",
-      params: [
-        {
-          forking: {
-            jsonRpcUrl: process.env.TEST_URI,
-            blockNumber: FORK_BLOCK,
-          },
-        },
-      ],
-    });
+    await forkBlock(FORK_BLOCK);
 
     // Fund & impersonate the admin account
     const [userSigner] = await ethers.getSigners();
@@ -63,9 +52,7 @@ describe("RibbonThetaVault upgrade", () => {
       "RibbonThetaVaultWBTCCall",
       "RibbonThetaVaultAAVECall",
     ];
-    deploymentNames.forEach((name) =>
-      vaults.push(deployments.mainnet[name])
-    );
+    deploymentNames.forEach((name) => vaults.push(deployments.mainnet[name]));
   });
 
   checkIfStorageNotCorrupted(deployments.mainnet.RibbonThetaVaultETHCall);


### PR DESCRIPTION
It takes a few minutes for hardhat tests to start up because it needs to load the state over the network. This caches the fork state so that it improves test speeds