### PR TITLE
Resolve options expiry to next friday

### DIFF
--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -813,6 +813,8 @@ library VaultLifecycle {
         }
         uint256 currentExpiry = IOtoken(currentOption).expiryTimestamp();
 
+        // After options expiry if no options are written for >1 week
+        // We need to give the ability continue writing options
         if (block.timestamp > currentExpiry + 7 days) {
             return getNextFriday(block.timestamp);
         }

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -61,16 +61,7 @@ library VaultLifecycle {
             uint256 delta
         )
     {
-        uint256 expiry;
-
-        // uninitialized state
-        if (closeParams.currentOption == address(0)) {
-            expiry = getNextFriday(block.timestamp);
-        } else {
-            expiry = getNextFriday(
-                IOtoken(closeParams.currentOption).expiryTimestamp()
-            );
-        }
+        uint256 expiry = getNextExpiry(closeParams.currentOption);
 
         IStrikeSelection selection = IStrikeSelection(strikeSelection);
 
@@ -811,27 +802,40 @@ library VaultLifecycle {
         );
     }
 
+    function getNextExpiry(address currentOption)
+        internal
+        view
+        returns (uint256)
+    {
+        // uninitialized state
+        if (currentOption == address(0)) {
+            return getNextFriday(block.timestamp);
+        }
+        uint256 currentExpiry = IOtoken(currentOption).expiryTimestamp();
+
+        if (block.timestamp > currentExpiry + 7 days) {
+            return getNextFriday(block.timestamp);
+        }
+        return getNextFriday(currentExpiry);
+    }
+
     /**
      * @notice Gets the next options expiry timestamp
-     * @param currentExpiry is the expiry timestamp of the current option
+     * @param timestamp is the expiry timestamp of the current option
      * Reference: https://codereview.stackexchange.com/a/33532
      * Examples:
      * getNextFriday(week 1 thursday) -> week 1 friday
      * getNextFriday(week 1 friday) -> week 2 friday
      * getNextFriday(week 1 saturday) -> week 2 friday
      */
-    function getNextFriday(uint256 currentExpiry)
-        internal
-        pure
-        returns (uint256)
-    {
+    function getNextFriday(uint256 timestamp) internal pure returns (uint256) {
         // dayOfWeek = 0 (sunday) - 6 (saturday)
-        uint256 dayOfWeek = ((currentExpiry / 1 days) + 4) % 7;
-        uint256 nextFriday = currentExpiry + ((7 + 5 - dayOfWeek) % 7) * 1 days;
+        uint256 dayOfWeek = ((timestamp / 1 days) + 4) % 7;
+        uint256 nextFriday = timestamp + ((7 + 5 - dayOfWeek) % 7) * 1 days;
         uint256 friday8am = nextFriday - (nextFriday % (24 hours)) + (8 hours);
 
-        // If the passed currentExpiry is day=Friday hour>8am, we simply increment it by a week to next Friday
-        if (currentExpiry >= friday8am) {
+        // If the passed timestamp is day=Friday hour>8am, we simply increment it by a week to next Friday
+        if (timestamp >= friday8am) {
             friday8am += 7 days;
         }
         return friday8am;

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -802,6 +802,10 @@ library VaultLifecycle {
         );
     }
 
+    /**
+     * @notice Gets the next option expiry timestamp
+     * @param currentOption is the otoken address that the vault is currently writing
+     */
     function getNextExpiry(address currentOption)
         internal
         view

--- a/contracts/libraries/VaultLifecycleSTETH.sol
+++ b/contracts/libraries/VaultLifecycleSTETH.sol
@@ -59,16 +59,8 @@ library VaultLifecycleSTETH {
             uint256 delta
         )
     {
-        uint256 expiry;
-
-        // uninitialized state
-        if (closeParams.currentOption == address(0)) {
-            expiry = VaultLifecycle.getNextFriday(block.timestamp);
-        } else {
-            expiry = VaultLifecycle.getNextFriday(
-                IOtoken(closeParams.currentOption).expiryTimestamp()
-            );
-        }
+        uint256 expiry =
+            VaultLifecycle.getNextExpiry(closeParams.currentOption);
 
         IStrikeSelection selection = IStrikeSelection(strikeSelection);
 

--- a/contracts/libraries/VaultLifecycleYearn.sol
+++ b/contracts/libraries/VaultLifecycleYearn.sol
@@ -60,16 +60,8 @@ library VaultLifecycleYearn {
             uint256 delta
         )
     {
-        uint256 expiry;
-
-        // uninitialized state
-        if (closeParams.currentOption == address(0)) {
-            expiry = VaultLifecycle.getNextFriday(block.timestamp);
-        } else {
-            expiry = VaultLifecycle.getNextFriday(
-                IOtoken(closeParams.currentOption).expiryTimestamp()
-            );
-        }
+        uint256 expiry =
+            VaultLifecycle.getNextExpiry(closeParams.currentOption);
 
         bool isPut = vaultParams.isPut;
 

--- a/contracts/tests/TestVaultLifecycle.sol
+++ b/contracts/tests/TestVaultLifecycle.sol
@@ -15,6 +15,14 @@ contract TestVaultLifecycle {
         return VaultLifecycle.getNextFriday(currentExpiry);
     }
 
+    function getNextExpiry(address currentOption)
+        external
+        view
+        returns (uint256 nextExpiry)
+    {
+        return VaultLifecycle.getNextExpiry(currentOption);
+    }
+
     function balanceOf(address account) public view returns (uint256) {
         if (account == address(this)) {
             return 1 ether;


### PR DESCRIPTION
Currently, we run into a situation where we are not able to roll the funds if you do not call `commitAndClose` 1 week within the options expiry. This changes it so that you could do so.