### PR TITLE
Increasing the cap for AURORA and NEAR in the deploy scripts, removing SUSHI tests, adding AURORA ETH puts

### DIFF
--- a/scripts/deploy/11_near_call_theta_vault.ts
+++ b/scripts/deploy/11_near_call_theta_vault.ts
@@ -95,7 +95,7 @@ const main = async ({
       asset: NEAR_ADDRESS[chainId],
       underlying: NEAR_ADDRESS[chainId],
       minimumSupply: BigNumber.from(10).pow(16),
-      cap: ethers.utils.parseUnits("1000", 24),
+      cap: ethers.utils.parseUnits("100000", 24),
     },
   ];
 

--- a/scripts/deploy/12_aurora_call_theta_vault.ts
+++ b/scripts/deploy/12_aurora_call_theta_vault.ts
@@ -97,7 +97,7 @@ const main = async ({
       asset: AURORA_ADDRESS[chainId],
       underlying: AURORA_ADDRESS[chainId],
       minimumSupply: BigNumber.from(10).pow(16),
-      cap: parseEther("1000"),
+      cap: parseEther("50000"),
     },
   ];
 

--- a/test/RibbonThetaVault.ts
+++ b/test/RibbonThetaVault.ts
@@ -9,7 +9,6 @@ import * as time from "./helpers/time";
 import {
   CHAINLINK_WBTC_PRICER_NEW,
   CHAINLINK_WETH_PRICER_NEW,
-  CHAINLINK_SUSHI_PRICER,
   CHAINID,
   BLOCK_NUMBER_NEW,
   ETH_PRICE_ORACLE,
@@ -25,8 +24,6 @@ import {
   WBTC_ADDRESS,
   WBTC_OWNER_ADDRESS,
   WETH_ADDRESS,
-  SUSHI_ADDRESS,
-  SUSHI_OWNER_ADDRESS,
   NEAR_ADDRESS,
   NEAR_OWNER_ADDRESS,
   CHAINLINK_NEAR_PRICER,
@@ -172,75 +169,7 @@ describe("RibbonThetaVault", () => {
     mintConfig: {
       contractOwnerAddress: USDC_OWNER_ADDRESS[chainId],
     },
-    availableChains: [CHAINID.ETH_MAINNET, CHAINID.AVAX_MAINNET],
-  });
-
-  behavesLikeRibbonOptionsVault({
-    name: `Ribbon SUSHI Theta Vault (Call)`,
-    tokenName: "Ribbon SUSHI Theta Vault",
-    tokenSymbol: "rSUSHI-THETA",
-    asset: SUSHI_ADDRESS[chainId],
-    assetContractName: "IWBTC",
-    strikeAsset: USDC_ADDRESS[chainId],
-    collateralAsset: SUSHI_ADDRESS[chainId],
-    chainlinkPricer: CHAINLINK_SUSHI_PRICER[chainId],
-    deltaFirstOption: BigNumber.from("1000"),
-    deltaSecondOption: BigNumber.from("1000"),
-    deltaStep: getDeltaStep("SUSHI"),
-    depositAmount: parseEther("1"),
-    minimumSupply: BigNumber.from("10").pow("10").toString(),
-    expectedMintAmount: BigNumber.from("100000000"),
-    premiumDiscount: BigNumber.from("997"),
-    managementFee: BigNumber.from("2000000"),
-    performanceFee: BigNumber.from("20000000"),
-    auctionDuration: 21600,
-    tokenDecimals: 18,
-    isPut: false,
-    isUsdcAuction: false,
-    gasLimits: {
-      depositWorstCase: 101000,
-      depositBestCase: 90000,
-    },
-    mintConfig: {
-      contractOwnerAddress: SUSHI_OWNER_ADDRESS[chainId],
-    },
-    availableChains: [CHAINID.ETH_MAINNET],
-  });
-
-  behavesLikeRibbonOptionsVault({
-    tokenName: "Ribbon SUSHI Theta Vault",
-    name: `Ribbon SUSHI Theta Vault (Call) (USDC Auction)`,
-    tokenSymbol: "rSUSHI-THETA",
-    asset: SUSHI_ADDRESS[chainId],
-    assetContractName: "IWBTC",
-    strikeAsset: USDC_ADDRESS[chainId],
-    collateralAsset: SUSHI_ADDRESS[chainId],
-    chainlinkPricer: CHAINLINK_SUSHI_PRICER[chainId],
-    deltaFirstOption: BigNumber.from("1000"),
-    deltaSecondOption: BigNumber.from("1000"),
-    deltaStep: getDeltaStep("SUSHI"),
-    depositAmount: parseEther("1"),
-    minimumSupply: BigNumber.from("10").pow("10").toString(),
-    expectedMintAmount: BigNumber.from("100000000"),
-    premiumDiscount: BigNumber.from("997"),
-    managementFee: BigNumber.from("2000000"),
-    performanceFee: BigNumber.from("20000000"),
-    auctionDuration: 21600,
-    tokenDecimals: 18,
-    isPut: false,
-    isUsdcAuction: true,
-    swapPath: {
-      tokens: [USDC_ADDRESS[chainId], SUSHI_ADDRESS[chainId]],
-      fees: [10000],
-    },
-    gasLimits: {
-      depositWorstCase: 101000,
-      depositBestCase: 90000,
-    },
-    mintConfig: {
-      contractOwnerAddress: SUSHI_OWNER_ADDRESS[chainId],
-    },
-    availableChains: [CHAINID.ETH_MAINNET],
+    availableChains: [CHAINID.ETH_MAINNET, CHAINID.AVAX_MAINNET, CHAINID.AURORA_MAINNET],
   });
 
   behavesLikeRibbonOptionsVault({


### PR DESCRIPTION
- fix/aurora-1 Increasing the cap for AURORA and NEAR in the deploy scripts
- task/sushi-tests Removing the RibbonThetaVault SUSHI tests and enabling AURORA ETH Puts
- Also enabled testing for ETH Puts on Aurora 