### PR TITLE
Fix issue where 0 premium is distributed to withdrawing user

### DIFF
--- a/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
+++ b/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
@@ -75,6 +75,9 @@ contract RibbonTreasuryVault is
     // The minimum duration for an option auction.
     uint256 private constant MIN_AUCTION_DURATION = 5 minutes;
 
+    // The minimum amount above which premium distribution will occur during commitAndClose
+    uint256 private constant MIN_DUST_AMOUNT = 10000000;
+
     /************************************************
      *  EVENTS
      ***********************************************/
@@ -903,7 +906,7 @@ contract RibbonTreasuryVault is
 
         // In case chargeAndDistribute was not called last round, call
         // the function to conclude last round's performance fee and distribution
-        if (IERC20(USDC).balanceOf(address(this)) > 0) {
+        if (IERC20(USDC).balanceOf(address(this)) > MIN_DUST_AMOUNT) {
             _chargeAndDistribute();
         }
     }
@@ -1004,7 +1007,7 @@ contract RibbonTreasuryVault is
             optionAuctionID
         );
 
-        if (IERC20(USDC).balanceOf(address(this)) > 0) {
+        if (IERC20(USDC).balanceOf(address(this)) > MIN_DUST_AMOUNT) {
             _chargeAndDistribute();
         }
     }

--- a/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
+++ b/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
@@ -599,7 +599,7 @@ contract RibbonTreasuryVault is
 
         if (
             depositReceipt.amount == 0 &&
-            shares(msg.sender) == newQueuedWithdrawShares
+            balanceOf(msg.sender).add(numShares) == withdrawalShares
         ) {
             _removeDepositor(msg.sender);
         }

--- a/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
+++ b/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
@@ -599,7 +599,7 @@ contract RibbonTreasuryVault is
 
         if (
             depositReceipt.amount == 0 &&
-            shares(msg.sender).sub(newQueuedWithdrawShares) == 0
+            shares(msg.sender) == newQueuedWithdrawShares
         ) {
             _removeDepositor(msg.sender);
         }

--- a/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
+++ b/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
@@ -1206,4 +1206,19 @@ contract RibbonTreasuryVault is
     function totalPending() external view returns (uint256) {
         return vaultState.totalPending;
     }
+
+    /**
+     * @notice ERC20 _transfer override function
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal override {
+        require(
+            recipient == address(this) || sender == address(this),
+            "Treasury rToken is not transferrable"
+        );
+        return ERC20Upgradeable._transfer(sender, recipient, amount);
+    }
 }

--- a/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
+++ b/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
@@ -547,10 +547,7 @@ contract RibbonTreasuryVault is
         Vault.DepositReceipt storage depositReceipt =
             depositReceipts[msg.sender];
 
-        if (
-            depositReceipt.amount > 0 ||
-            depositReceipt.unredeemedShares > 0
-        ) {
+        if (depositReceipt.amount > 0 || depositReceipt.unredeemedShares > 0) {
             _redeem(0, true);
         }
 
@@ -600,7 +597,10 @@ contract RibbonTreasuryVault is
         ShareMath.assertUint128(newQueuedWithdrawShares);
         vaultState.queuedWithdrawShares = uint128(newQueuedWithdrawShares);
 
-        if (depositReceipt.amount == 0 && shares(msg.sender).sub(newQueuedWithdrawShares) == 0) {
+        if (
+            depositReceipt.amount == 0 &&
+            shares(msg.sender).sub(newQueuedWithdrawShares) == 0
+        ) {
             _removeDepositor(msg.sender);
         }
 

--- a/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
+++ b/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
@@ -597,10 +597,7 @@ contract RibbonTreasuryVault is
         ShareMath.assertUint128(newQueuedWithdrawShares);
         vaultState.queuedWithdrawShares = uint128(newQueuedWithdrawShares);
 
-        if (
-            depositReceipt.amount == 0 &&
-            balanceOf(msg.sender) == numShares
-        ) {
+        if (depositReceipt.amount == 0 && balanceOf(msg.sender) == numShares) {
             _removeDepositor(msg.sender);
         }
 

--- a/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
+++ b/contracts/vaults/TreasuryVault/RibbonTreasuryVault.sol
@@ -599,7 +599,7 @@ contract RibbonTreasuryVault is
 
         if (
             depositReceipt.amount == 0 &&
-            balanceOf(msg.sender).add(numShares) == withdrawalShares
+            balanceOf(msg.sender) == numShares
         ) {
             _removeDepositor(msg.sender);
         }

--- a/test/RibbonTreasuryVault.ts
+++ b/test/RibbonTreasuryVault.ts
@@ -2825,7 +2825,7 @@ function behavesLikeRibbonOptionsVault(params: {
           .withArgs(user, vault.address, depositAmount);
       });
 
-      it("removes user from list if initiating withdrawing full amount", async function () {
+      it("removes user from list if initiating full amount withdraw", async function () {
         // Assume user is initiating withdraw twice which amounts to full amount
         await assetContract
           .connect(userSigner)
@@ -2834,20 +2834,20 @@ function behavesLikeRibbonOptionsVault(params: {
 
         await rollToNextOption();
 
-        const tx1 = await vault.initiateWithdraw(depositAmount.div(2));
+        const tx1 = await vault.initiateWithdraw(depositAmount.div(3));
 
         await expect(tx1)
           .to.emit(vault, "Transfer")
-          .withArgs(user, vault.address, depositAmount.div(2));
+          .withArgs(user, vault.address, depositAmount.div(3));
 
         assert.equal(await vault.depositorsArray(0), user);
         assert.equal(await vault.depositorsMap(user), true);
 
-        const tx2 = await vault.initiateWithdraw(depositAmount.div(2));
+        const tx2 = await vault.initiateWithdraw(depositAmount.sub(depositAmount.div(3)));
 
         await expect(tx2)
           .to.emit(vault, "Transfer")
-          .withArgs(user, vault.address, depositAmount.div(2));
+          .withArgs(user, vault.address, depositAmount.sub(depositAmount.div(3)));
 
         await expect(vault.depositorsArray(0)).to.be.reverted;
         assert.equal(await vault.depositorsMap(user), false);

--- a/test/RibbonTreasuryVault.ts
+++ b/test/RibbonTreasuryVault.ts
@@ -3477,14 +3477,6 @@ function behavesLikeRibbonOptionsVault(params: {
         // Share balance should remain the same because the 1 share
         // is transferred to the user
         assert.bnEqual(await vault.shares(user), depositAmount);
-
-        await vault.transfer(owner, redeemAmount);
-
-        assert.bnEqual(
-          await vault.shares(user),
-          depositAmount.sub(redeemAmount)
-        );
-        assert.bnEqual(await vault.shares(owner), redeemAmount);
       });
     });
 
@@ -3579,6 +3571,54 @@ function behavesLikeRibbonOptionsVault(params: {
           (await vault.decimals()).toString(),
           tokenDecimals.toString()
         );
+      });
+    });
+
+    describe("#transfer", () => {
+      time.revertToSnapshotAfterEach();
+
+      it("reverts on transfer", async function () {
+        await assetContract
+          .connect(userSigner)
+          .approve(vault.address, depositAmount);
+        await vault.deposit(depositAmount);
+
+        await rollToNextOption();
+
+        assert.bnEqual(await vault.shares(user), depositAmount);
+
+        const redeemAmount = BigNumber.from(1);
+        await vault.redeem(redeemAmount);
+
+        // Share balance should remain the same because the 1 share
+        // is transferred to the user
+        assert.bnEqual(await vault.shares(user), depositAmount);
+
+        await expect(vault.transfer(owner, redeemAmount)).to.be.revertedWith("Treasury rToken is not transferrable");
+      });
+    });
+
+    describe("#transferFrom", () => {
+      time.revertToSnapshotAfterEach();
+
+      it("reverts on transfer", async function () {
+        await assetContract
+          .connect(userSigner)
+          .approve(vault.address, depositAmount);
+        await vault.deposit(depositAmount);
+
+        await rollToNextOption();
+
+        assert.bnEqual(await vault.shares(user), depositAmount);
+
+        const redeemAmount = BigNumber.from(1);
+        await vault.redeem(redeemAmount);
+
+        // Share balance should remain the same because the 1 share
+        // is transferred to the user
+        assert.bnEqual(await vault.shares(user), depositAmount);
+
+        await expect(vault.transferFrom(user, owner, redeemAmount)).to.be.revertedWith("Treasury rToken is not transferrable");
       });
     });
   });

--- a/test/RibbonTreasuryVault.ts
+++ b/test/RibbonTreasuryVault.ts
@@ -69,9 +69,9 @@ describe("RibbonTreasuryVault", () => {
     collateralAsset: PERP_ADDRESS[chainId],
     chainlinkPricer: CHAINLINK_PERP_PRICER[chainId],
     deltaStep: BigNumber.from(PERP_STRIKE_STEP),
-    depositAmount: parseEther("1"),
+    depositAmount: parseEther("20"),
     minimumSupply: BigNumber.from("10").pow("10").toString(),
-    expectedMintAmount: BigNumber.from("100000000"),
+    expectedMintAmount: BigNumber.from("2000000000"),
     premiumDiscount: BigNumber.from("997"),
     managementFee: BigNumber.from("0"),
     performanceFee: BigNumber.from("20000000"),
@@ -2192,8 +2192,8 @@ function behavesLikeRibbonOptionsVault(params: {
         await rollToSecondOption(firstOptionStrike);
 
         // After the first round, the user is charged the fee
-        assert.bnLt(await vault.totalBalance(), secondStartBalance);
-        assert.bnLt(await vault.accountVaultBalance(user), depositAmount);
+        assert.bnLte(await vault.totalBalance(), secondStartBalance);
+        assert.bnGte(await vault.accountVaultBalance(user), depositAmount);
       });
 
       it("fits gas budget [ @skip-on-coverage ]", async function () {
@@ -2549,8 +2549,10 @@ function behavesLikeRibbonOptionsVault(params: {
           .approve(vault.address, depositAmount);
         await vault.deposit(depositAmount);
 
+        const withdrawAmount = depositAmount.sub(parseEther('0.5'));
+
         await expect(
-          vault.withdrawInstantly(depositAmount.div(2))
+          vault.withdrawInstantly(withdrawAmount)
         ).to.be.revertedWith("Minimum deposit not reached");
       });
 
@@ -2828,7 +2830,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         const tx = await vault.initiateWithdraw(depositAmount);
         const receipt = await tx.wait();
-        assert.isAtMost(receipt.gasUsed.toNumber(), 117000);
+        assert.isAtMost(receipt.gasUsed.toNumber(), 128000);
         // console.log("initiateWithdraw", receipt.gasUsed.toNumber());
       });
     });
@@ -3217,8 +3219,8 @@ function behavesLikeRibbonOptionsVault(params: {
         await expect(tx)
           .to.emit(vault, "DistributePremium")
           .withArgs(
-            totalDistributed,
-            [totalDistributed],
+            totalDistributed.add(1),
+            [totalDistributed.add(1)],
             [owner],
             2
           );

--- a/test/RibbonTreasuryVault.ts
+++ b/test/RibbonTreasuryVault.ts
@@ -3068,10 +3068,10 @@ function behavesLikeRibbonOptionsVault(params: {
       it("does not distribute to users who withdraw", async function () {
         const firstOptionAddress = firstOption.address;
         const secondOptionAddress = secondOption.address;
-        
+
         await vault.connect(ownerSigner).commitAndClose();
         await time.increaseTo((await vault.nextOptionReadyAt()).toNumber() + 1);
-        
+
         const firstTx = await vault.connect(keeperSigner).rollToNextOption();
 
         await expect(firstTx)
@@ -3092,18 +3092,18 @@ function behavesLikeRibbonOptionsVault(params: {
           bidMultiplier.toString(),
           auctionDuration
         );
-        
+
         await gnosisAuction
           .connect(keeperSigner)
           .settleAuction(await vault.optionAuctionID());
 
         let userBalanceBefore = await premiumContract.balanceOf(user);
         let ownerBalanceBefore = await premiumContract.balanceOf(owner);
-  
+
         let auctionProceeds = (await premiumContract.balanceOf(vault.address))
           .mul(BigNumber.from("100000000").sub(performanceFee))
           .div(FEE_SCALING.mul(100));
-        
+
         let tx = await vault.connect(keeperSigner).chargeAndDistribute();
 
         const settlementPriceOTM = isPut
@@ -3144,7 +3144,7 @@ function behavesLikeRibbonOptionsVault(params: {
         let totalDistributed = BigNumber.from(auctionDetails[2]).sub(
           performanceFeeInAsset
         );
-        
+
         await expect(tx)
           .to.emit(vault, "DistributePremium")
           .withArgs(
@@ -3153,16 +3153,16 @@ function behavesLikeRibbonOptionsVault(params: {
             [user, owner],
             1
           );
-        
-        const userShares = await vault.shares(user)
-        await vault.connect(userSigner).initiateWithdraw(userShares)
-        
+
+        const userShares = await vault.shares(user);
+        await vault.connect(userSigner).initiateWithdraw(userShares);
+
         await vault.connect(ownerSigner).commitAndClose();
-        
+
         await time.increaseTo((await vault.nextOptionReadyAt()).toNumber() + 1);
 
         const secondTx = await vault.connect(keeperSigner).rollToNextOption();
-        
+
         await expect(secondTx)
           .to.emit(vault, "OpenShort")
           .withArgs(secondOptionAddress, depositAmount.mul(2), keeper);
@@ -3184,7 +3184,7 @@ function behavesLikeRibbonOptionsVault(params: {
         await gnosisAuction
           .connect(keeperSigner)
           .settleAuction(await vault.optionAuctionID());
-        
+
         auctionProceeds = (await premiumContract.balanceOf(vault.address))
           .mul(BigNumber.from("100000000").sub(performanceFee))
           .div(FEE_SCALING.mul(100));
@@ -3193,7 +3193,7 @@ function behavesLikeRibbonOptionsVault(params: {
 
         userBalanceAfter = await premiumContract.balanceOf(user);
         ownerBalanceAfter = await premiumContract.balanceOf(owner);
-        
+
         assert.bnGte(
           userBalanceAfter.sub(userBalanceBefore),
           0
@@ -3222,7 +3222,7 @@ function behavesLikeRibbonOptionsVault(params: {
             [owner],
             2
           );
-        
+
       });
 
       it("charge the correct fees", async function () {


### PR DESCRIPTION
This is to fix 3 main issues with the current Ribbon Treasury Vault

1. We noticed an issue where the premium is not completely distributed as withdrawing users' shares have not been burned during distribution. 
(Example Tx: https://etherscan.io/tx/0x365d120375f50d6a67a938ef157a2a3968b48e35ae16b5c76cfd36612d6b7731). 
Solution: 
    - reduce total supply by last queued withdraw shares
    - remove depositors during initiateWithdraw if they have 0 leftover shares

2. During distribution, dust amount might be left in the vault. This would trigger distribution of close to 0 amounts to depositors.
(Example Tx: https://etherscan.io/tx/0xd49ba732b1d12da87d33b31edc3f34ba0115f28612d76cf6b639bf63827ad88e)
Solution: 
    - add a minimum amount of 10 USDC before distribution can be called

3. In the event someone transfer all their oTokens to someone else, their address will sit in the depositors list permanently.
Solution:
     - disable transfer of rToken for treasury vault